### PR TITLE
Implement caching for GitHub API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ build/
 update_log.txt
 logs/
 
+# Cache files
+app/tasmota/cache/
+*.json.cache
+
 # Local configuration
 .env
 .env.local

--- a/app/tasmota/updater.py
+++ b/app/tasmota/updater.py
@@ -12,7 +12,7 @@ import os
 import socket
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # Setup module logger
@@ -145,14 +145,97 @@ def compare_versions(device_version, latest_version):
     return False
 
 
+def get_cached_data(cache_name: str, max_age_days: int = 1) -> tuple[dict, bool]:
+    """
+    Get data from cache if it exists and is not expired
+    
+    Args:
+        cache_name: Name of the cache file (without extension)
+        max_age_days: Maximum age of cache in days before it's considered expired
+        
+    Returns:
+        tuple: (cached_data, is_valid)
+            - cached_data: The cached data or None if not available
+            - is_valid: True if cache is valid and not expired, False otherwise
+    """
+    # Cache file path
+    cache_dir = Path(os.path.dirname(os.path.abspath(__file__))) / "cache"
+    cache_file = cache_dir / f"{cache_name}.json"
+    
+    # Create cache directory if it doesn't exist
+    if not cache_dir.exists():
+        cache_dir.mkdir(exist_ok=True)
+    
+    # Check if cache exists and is valid
+    if cache_file.exists():
+        try:
+            with open(cache_file, 'r') as f:
+                cache_data = json.load(f)
+                
+            # Check if cache is still valid
+            cache_timestamp = datetime.fromisoformat(cache_data['cache_timestamp'])
+            if datetime.now() - cache_timestamp < timedelta(days=max_age_days):
+                logger.debug(f"Using cached data for {cache_name} (cached at {cache_timestamp})")
+                return cache_data['data'], True
+            else:
+                logger.debug(f"Cache expired for {cache_name}, fetching fresh data")
+        except Exception as e:
+            logger.warning(f"Error reading cache file {cache_name}: {e}")
+    
+    return None, False
+
+
+def save_to_cache(cache_name: str, data: dict) -> bool:
+    """
+    Save data to cache file
+    
+    Args:
+        cache_name: Name of the cache file (without extension)
+        data: Data to cache
+        
+    Returns:
+        bool: True if successfully saved to cache, False otherwise
+    """
+    # Cache file path
+    cache_dir = Path(os.path.dirname(os.path.abspath(__file__))) / "cache"
+    cache_file = cache_dir / f"{cache_name}.json"
+    
+    # Create cache directory if it doesn't exist
+    if not cache_dir.exists():
+        cache_dir.mkdir(exist_ok=True)
+    
+    try:
+        cache_data = {
+            'cache_timestamp': datetime.now().isoformat(),
+            'data': data
+        }
+        with open(cache_file, 'w') as f:
+            json.dump(cache_data, f, indent=2)
+        logger.debug(f"Saved data to cache: {cache_name}")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to write cache file {cache_name}: {e}")
+        return False
+
+
 def fetch_latest_tasmota_release():
     """
     Fetch information about the latest official Tasmota release from GitHub
+    Results are cached for one day to prevent GitHub API rate limit issues
     
     Returns:
         dict: Dictionary containing release information or None if failed
               Keys: 'version', 'release_date', 'release_notes', 'download_url'
     """
+    # Hard-coded URL for release notes
+    RELEASE_NOTES_URL = "https://github.com/arendst/Tasmota/releases/"
+    
+    # Try to get data from cache
+    cached_data, is_valid = get_cached_data('latest_release')
+    if is_valid and cached_data:
+        return cached_data
+    
+    # Cache doesn't exist, is invalid, or couldn't be read - fetch fresh data
     try:
         # GitHub API URL for Tasmota releases
         url = "https://api.github.com/repos/arendst/Tasmota/releases/latest"
@@ -187,13 +270,18 @@ def fetch_latest_tasmota_release():
             
             logger.info(f"Latest Tasmota release: {version}, published on {release_date_str}")
             
-            return {
+            release_info = {
                 'version': version,
                 'release_date': release_date_str,
                 'release_notes': release_data['body'],
                 'download_url': download_url,
-                'release_url': release_data['html_url']
+                'release_url': RELEASE_NOTES_URL  # Use the hard-coded URL instead of the dynamic one
             }
+            
+            # Save to cache
+            save_to_cache('latest_release', release_info)
+            
+            return release_info
         else:
             logger.error(f"Failed to fetch latest release. Status code: {response.status_code}")
     
@@ -306,169 +394,3 @@ def update_device_firmware(device_ip, username=None, password=None, check_only=F
         result["message"] = f"Error connecting to device: {e}"
     
     return result
-
-
-
-
-
-def fetch_latest_tasmota_release():
-    """
-    Fetch information about the latest official Tasmota release from GitHub
-    
-    Returns:
-        dict: Dictionary containing release information or None if failed
-              Keys: version, release_date, release_notes, download_url
-    """
-    try:
-        # GitHub API URL for Tasmota releases
-        url = "https://api.github.com/repos/arendst/Tasmota/releases/latest"
-        
-        logger.debug("Fetching latest Tasmota release information from GitHub")
-        response = requests.get(url, timeout=10)
-        
-        if response.status_code == 200:
-            release_data = response.json()
-            
-            # Extract version from tag name (remove v prefix if present)
-            version = release_data["tag_name"]
-            if version.startswith("v"):
-                version = version[1:]
-            
-            # Extract release date and format it
-            release_date_str = release_data["published_at"].split("T")[0]
-            
-            # Extract download URL for the main firmware binary
-            download_url = None
-            for asset in release_data["assets"]:
-                if asset["name"].lower() == "tasmota.bin":
-                    download_url = asset["browser_download_url"]
-                    break
-            
-            # If we could not find tasmota.bin, use the first .bin file
-            if not download_url:
-                for asset in release_data["assets"]:
-                    if asset["name"].lower().endswith(".bin"):
-                        download_url = asset["browser_download_url"]
-                        break
-            
-            logger.info(f"Latest Tasmota release: {version}, published on {release_date_str}")
-            
-            return {
-                "version": version,
-                "release_date": release_date_str,
-                "release_notes": release_data["body"],
-                "download_url": download_url
-            }
-        else:
-            logger.error(f"Failed to fetch latest release. Status code: {response.status_code}")
-    
-    except Exception as e:
-        logger.error(f"Error fetching latest release: {e}")
-    
-    return None
-
-
-def update_device_firmware(device_ip, username=None, password=None, check_only=False):
-    """
-    Update firmware on a single Tasmota device
-    
-    Args:
-        device_ip (str): IP address of the device
-        username (str, optional): Username for authentication
-        password (str, optional): Password for authentication
-        check_only (bool): If True, only check firmware version without updating
-    
-    Returns:
-        dict: Result information including success status and version details
-    """
-    result = {
-        "ip": device_ip,
-        "success": False,
-        "message": "",
-        "current_version": "Unknown",
-        "latest_version": "Unknown",
-        "needs_update": False,
-        "dns_name": get_dns_name(device_ip)
-    }
-    
-    # Get current firmware version
-    firmware_info = get_device_firmware_version(device_ip, username, password)
-    if not firmware_info:
-        result["message"] = "Failed to get current firmware version"
-        return result
-    
-    result["current_version"] = firmware_info["version"]
-    
-    # Get latest release information
-    latest_release = fetch_latest_tasmota_release()
-    if not latest_release:
-        result["message"] = "Failed to get latest release information"
-        return result
-    
-    result["latest_version"] = latest_release["version"]
-    
-    # Check if update is needed
-    needs_update = compare_versions(firmware_info["version"], latest_release["version"])
-    result["needs_update"] = needs_update
-    
-    if not needs_update:
-        result["message"] = "Device is already running the latest version"
-        result["success"] = True
-        return result
-    
-    if check_only:
-        result["message"] = "Update available"
-        result["success"] = True
-        return result
-    
-    # Construct base URL with authentication if provided
-    if username and password:
-        base_url = f"http://{username}:{password}@{device_ip}/cm"
-    else:
-        base_url = f"http://{device_ip}/cm"
-    
-    try:
-        # Send upgrade command
-        logger.info(f"{device_ip}: Upgrading to latest official release")
-        params = {"cmnd": "Upgrade 1"}
-        response = requests.get(base_url, params=params, timeout=5)
-        
-        if response.status_code != 200:
-            result["message"] = f"Failed to send upgrade command. Status code: {response.status_code}"
-            return result
-        
-        # Wait for device to restart (typically takes 10-30 seconds)
-        logger.info(f"{device_ip}: Waiting for device to restart and come back online")
-        time.sleep(5)  # Initial wait to allow device to start update
-        
-        # Check if device comes back online
-        max_wait = 60  # Maximum wait time in seconds
-        wait_interval = 5  # Check interval in seconds
-        for _ in range(max_wait // wait_interval):
-            try:
-                check_response = requests.get(f"http://{device_ip}", timeout=2)
-                if check_response.status_code == 200:
-                    # Device is back online
-                    result["success"] = True
-                    result["message"] = "Update successful"
-                    
-                    # Get new firmware version
-                    new_firmware_info = get_device_firmware_version(device_ip, username, password)
-                    if new_firmware_info:
-                        result["current_version"] = new_firmware_info["version"]
-                    
-                    return result
-            except requests.exceptions.RequestException:
-                # Device still not reachable, continue waiting
-                pass
-            
-            time.sleep(wait_interval)
-        
-        # If we get here, device did not come back online in time
-        result["message"] = "Update initiated but device did not come back online within timeout period"
-        
-    except requests.exceptions.RequestException as e:
-        result["message"] = f"Error connecting to device: {e}"
-    
-    return result
-


### PR DESCRIPTION
## Changes

- Extract caching mechanism to reusable functions (get_cached_data and save_to_cache)
- Use hard-coded URL for Tasmota release notes: https://github.com/arendst/Tasmota/releases/
- Remove duplicate functions from codebase
- Add cache directory to .gitignore
- Ensure cache directory is created if it doesn't exist

## Benefits

- Prevents GitHub API rate limit issues by caching results for one day
- Improves code organization with reusable caching functions
- Follows functional programming principles
- Removes duplicate code to improve maintainability

## Testing

- Verified that the code compiles successfully
- Ensured cache directory is created automatically when needed
- Confirmed caching mechanism works correctly