### PR TITLE
release: v0.3.0

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -3,7 +3,7 @@
 Version information for the Tasmota Updater application.
 """
 
-__version__ = "0.2.2"  # Updated docker/build-push-action dependency
+__version__ = "0.3.0"  # Security hardening + Flask 3 upgrade; optional API_KEY/GITHUB_TOKEN auth; CORS same-origin default
 """
 Version string following Semantic Versioning (SemVer) format: MAJOR.MINOR.PATCH
 - MAJOR: Incompatible API changes


### PR DESCRIPTION
Bumps version to **0.3.0** for the security-hardening + dependency-upgrade release (merged in #44).

Highlights since v0.2.1:
- Security: optional `API_KEY` gate on /api/*, CORS same-origin default (set `CORS_ORIGINS` to allow cross-origin), no `dev` SECRET_KEY fallback, device-IP validation, hardened JSON parsing, optional `GITHUB_TOKEN` for release lookups.
- Dependencies: Flask 2.x → 3.1.x, Werkzeug 3.1.x, marshmallow 4.x, gunicorn 26, flask-cors 6, etc.
- CI: 9 GitHub Actions bumped.

Tagging v0.3.0 after merge publishes multi-arch images to Docker Hub + GHCR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>