### PR TITLE
fix(ci): stop Dependabot PR pileup from per-PR version.py bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     labels:
       - "dependencies"
       - "python"
-      - "semver:patch"
     commit-message:
       prefix: "pip"
       include: "scope"
@@ -22,7 +21,16 @@ updates:
     reviewers:
       - "dodjango"
     versioning-strategy: "auto"
-    
+    # Bundle all patch/minor bumps into one weekly PR (auto-merged).
+    # Major bumps stay separate so they can be reviewed individually.
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # Check for updates to GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -36,7 +44,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-      - "semver:patch"
     commit-message:
       prefix: "github-actions"
       include: "scope"
@@ -44,6 +51,13 @@ updates:
       - "dodjango"
     reviewers:
       - "dodjango"
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -57,7 +71,6 @@ updates:
     labels:
       - "dependencies"
       - "docker"
-      - "semver:patch"
     commit-message:
       prefix: "docker"
       include: "scope"
@@ -66,3 +79,10 @@ updates:
     reviewers:
       - "dodjango"
     versioning-strategy: "auto"
+    groups:
+      docker-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,80 +1,43 @@
-name: Dependabot Auto-Merge and Version Bump
+name: Dependabot Auto-Merge
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
+# Auto-merges Dependabot PRs for patch and minor updates. Major updates are
+# left open with a comment for manual review. No version.py bump happens here
+# anymore — that caused every PR to touch the same line and conflict, which
+# stalled the whole queue. App version bumps belong to the release process.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  auto-merge-and-version:
+  auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    permissions:
-      contents: write
-      pull-requests: write
-    
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-      
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
-      
-      - name: Determine version bump type
-        id: bump-type
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'semver:major') }}" == "true" ]]; then
-            echo "bump=major" >> $GITHUB_OUTPUT
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'semver:minor') }}" == "true" ]]; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-          else
-            echo "bump=patch" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Update version file
-        run: |
-          BUMP_TYPE="${{ steps.bump-type.outputs.bump }}"
-          VERSION_FILE="app/version.py"
-          
-          # Extract current version
-          CURRENT_VERSION=$(grep -oP '__version__ = "\K[^"]+' "$VERSION_FILE")
-          echo "Current version: $CURRENT_VERSION"
-          
-          # Split version into components
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-          
-          # Bump version according to SemVer rules
-          if [ "$BUMP_TYPE" == "major" ]; then
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-          elif [ "$BUMP_TYPE" == "minor" ]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
-          else
-            PATCH=$((PATCH + 1))
-          fi
-          
-          # Create new version string
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          echo "New version: $NEW_VERSION"
-          
-          # Update version in file
-          sed -i "s/__version__ = \"$CURRENT_VERSION\"/__version__ = \"$NEW_VERSION\"/" "$VERSION_FILE"
-          
-          # Commit the version change
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add "$VERSION_FILE"
-          git commit -m "Bump version to $NEW_VERSION for Dependabot PR"
-          git push
-      
-      - name: Enable auto-merge
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major updates for manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "🚧 Major-Update (\`${DEP_NAMES}\`) — Auto-Merge ist deaktiviert. Bitte manuell reviewen und mergen."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`dependabot-auto-merge.yml` committete in **jeden** Dependabot-PR einen `app/version.py`-Bump und aktivierte dann Auto-Merge. Weil alle PRs dieselbe `version.py`-Zeile ändern, konnte nach dem ersten Merge **keiner der übrigen mehr konfliktfrei mergen** → die Queue lief voll (zuletzt 14 festhängende PRs, konsolidiert in #61).

Zusätzlich: die semver-Steuerung war wirkungslos, weil `dependabot.yml` bei allen PRs statisch `semver:patch` als Label setzte — der Workflow konnte den echten Bump-Typ nie erkennen und hat faktisch **alles** auto-gemergt, auch Majors.

## Änderungen

**`dependabot-auto-merge.yml`**
- ❌ `version.py`-Bump/commit/push entfernt (die Konflikt-Ursache). App-Versionierung gehört in den Release-Prozess.
- ❌ `checkout`-Step entfernt (nicht mehr nötig; war zudem ein Workflow-Injection-Risiko über `ref: head.ref`).
- ✅ `dependabot/fetch-metadata@v2` liefert den echten `update-type`.
- ✅ Auto-Merge nur noch für **patch/minor**; **Major**-Updates bleiben offen und bekommen einen Review-Kommentar (dependency-guard-konform).
- ✅ `dependency-names` wird über `env:` gereicht (kein Inline-`${{ }}` im `run:`).

**`dependabot.yml`**
- ✅ `groups` pro Ökosystem (pip, github-actions, docker): patch+minor → **ein** wöchentlicher Sammel-PR statt bis zu 10 Einzel-PRs. Majors bleiben separat.
- ❌ irreführendes hardcoded `semver:patch`-Label entfernt.

## Ergebnis

- Kein gegenseitiger `version.py`-Konflikt mehr → Auto-Merge kann tatsächlich durchlaufen.
- Deutlich weniger PR-Rauschen (1 Sammel-PR/Woche/Ökosystem).
- Majors werden nicht mehr still auto-gemergt.

## ⚠️ Voraussetzung (Repo-Setting)

`gh pr merge --auto` braucht **„Allow auto-merge"** in den Repo-Settings + eine Branch-Protection-Regel mit Required Checks auf `main`. Ist das nicht gesetzt, schlägt der Auto-Merge-Step fehl (aber ohne die alte Konflikt-Blockade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)