### PR TITLE
ci: fix container-publish dispatch in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run "Publish Container Image" --ref "$TAG"
+        run: gh workflow run "Publish Container Image" --repo "$GITHUB_REPOSITORY" --ref "$TAG"


### PR DESCRIPTION
Beim ersten echten Release (v0.3.1) schlug der release-please-Step *Trigger container publish* fehl:

```
failed to run git: fatal: not a git repository
```

**Ursache:** Der release-please-Job macht kein `actions/checkout` (release-please arbeitet per API). Ohne Git-Kontext kann `gh workflow run` das Repo nicht bestimmen.

**Fix:** `--repo "$GITHUB_REPOSITORY"` explizit mitgeben.

Tag + GitHub-Release v0.3.1 entstanden korrekt; nur das versionierte Container-Image wurde nicht gebaut (nur `latest` via push:main) — **manuell via workflow_dispatch nachgeholt**. Ab dem nächsten Release greift der Dispatch automatisch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)