### PR TITLE
docs + fix: audit plan and Phase 0 quick wins

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,6 +57,10 @@ USER appuser
 # Expose the port the app runs on
 EXPOSE 5001
 
+# Container healthcheck — the slim image has no curl, so use the Python stdlib.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')" || exit 1
+
 # Use tini as init process to handle signals properly
 ENTRYPOINT ["/usr/bin/tini", "--"]
 

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -70,6 +70,12 @@ body {
 .card-footer-item[disabled] {
     opacity: 0.5;
     cursor: not-allowed;
+    pointer-events: none;
+}
+
+/* Alpine.js: hide cloaked elements until initialised (the CDN build omits this rule) */
+[x-cloak] {
+    display: none !important;
 }
 
 /* Loading spinner */

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -51,10 +51,10 @@ function tasmotaApp() {
             this.isLoading = true;
             this.error = '';
             
+            const timeoutValue = 60; // Default to 60 seconds for device listing
             try {
                 // Create an AbortController
                 const controller = new AbortController();
-                const timeoutValue = 60; // Default to 10 seconds for device listing
                 
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
@@ -100,10 +100,10 @@ function tasmotaApp() {
         },
         
         async fetchLatestRelease() {
+            const timeoutValue = 10; // Default to 10 seconds for release info
             try {
                 // Create an AbortController
                 const controller = new AbortController();
-                const timeoutValue = 10; // Default to 10 seconds for release info
                 
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
@@ -169,10 +169,10 @@ function tasmotaApp() {
         async checkDeviceUpdate(device) {
             if (!device.status) return;
             console.log(`Checking update status for ${device.ip}`);
+            const timeoutValue = device.timeout || 60; // Default to 60 seconds
             try {
                 // Create an AbortController
                 const controller = new AbortController();
-                const timeoutValue = device.timeout || 60; // Default to 10 seconds
                 
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
@@ -292,7 +292,8 @@ function tasmotaApp() {
             
             // Get user preference for update filtering
             const updateOnlyNeeded = localStorage.getItem('update_only_needed') !== 'false';
-            
+            const timeoutValue = 60; // Default to 60 seconds for batch updates
+
             try {
                 // First, mark all devices as pending update
                 this.devices.forEach(device => {
@@ -307,7 +308,6 @@ function tasmotaApp() {
                 
                 // Create an AbortController
                 const controller = new AbortController();
-                const timeoutValue = 60; // Default to 60 seconds for batch updates
                 
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
@@ -395,10 +395,10 @@ function tasmotaApp() {
                 device.isChecking = true;
             });
             
+            const timeoutValue = 60; // Default to 60 seconds for batch checks
             try {
                 // Create an AbortController
                 const controller = new AbortController();
-                const timeoutValue = 60; // Default to 60 seconds for batch checks
                 
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -23,7 +23,6 @@ class DeviceSchema(Schema):
 
     class Meta:
         fields = ("ip", "username", "password")
-        required = ("ip",)
 
 
 class DeviceUpdateSchema(Schema):
@@ -36,7 +35,6 @@ class DeviceUpdateSchema(Schema):
 
     class Meta:
         fields = ("ip", "username", "password", "check_only", "timeout")
-        required = ("ip",)
 
 
 # API Resources
@@ -327,7 +325,7 @@ class DeviceUpdateResource(Resource):
             # Update device firmware with enhanced timeout handling
             result = update_device_firmware(device_config, check_only)
         else:
-            result = {'error': 'Device not found'}, 404
+            return {'error': 'Device not found'}, 404
         
         return jsonify(result)
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,15 +11,20 @@
 </head>
 <body>
     <div x-data="tasmotaApp()" x-init="init()">
-        <nav class="navbar is-primary" role="navigation" aria-label="main navigation">
+        <nav class="navbar is-primary" role="navigation" aria-label="main navigation" x-data="{ navOpen: false }">
             <div class="navbar-brand">
                 <a class="navbar-item" href="/" title="Return to home page">
                     <img src="{{ url_for('static', filename='images/tasmota-logo.png') }}" alt="Tasmota Logo" width="112" height="28">
                     <span class="has-text-weight-bold ml-2">Tasmota Updater</span>
                 </a>
+                <a role="button" class="navbar-burger" :class="{ 'is-active': navOpen }" @click="navOpen = !navOpen" aria-label="menu" :aria-expanded="navOpen.toString()">
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                </a>
             </div>
-            
-            <div class="navbar-menu">
+
+            <div class="navbar-menu" :class="{ 'is-active': navOpen }">
                 <div class="navbar-end">
                     <div class="navbar-item">
                         <div class="buttons">
@@ -102,12 +107,6 @@
                     <p class="mt-2">Loading devices...</p>
                 </div>
                 
-                <!-- Error message -->
-                <div class="notification is-danger" x-show="error">
-                    <button class="delete" @click="error = ''" title="Dismiss this error message"></button>
-                    <p x-text="error"></p>
-                </div>
-                
                 <!-- No devices message -->
                 <div class="notification is-info" x-show="!isLoading && devices.length === 0 && !error">
                     <p>No devices found. Please add devices to your configuration file.</p>
@@ -118,7 +117,7 @@
                     <template x-for="device in devices" :key="device.ip">
                         <div class="column is-one-third">
                             <div class="card">
-                                <header class="card-header" @click="window.open(getDeviceUrl(device), '_blank')" style="cursor: pointer;" title="Open device web interface in a new tab">
+                                <header class="card-header" @click="window.open(getDeviceUrl(device), '_blank', 'noopener')" style="cursor: pointer;" title="Open device web interface in a new tab">
                                     <p class="card-header-title">
                                         <span x-text="device.ip"></span>
                                         <span x-show="device.dns_name" class="tag is-info is-light ml-2" x-text="device.dns_name"></span>

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -21,7 +21,10 @@ services:
     environment:
       # Use environment variable with fallback
       - DEVICES_FILE=${DEVICES_FILE:-devices.yaml}
-      - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
+      # SECRET_KEY: leave unset and the app generates an ephemeral random key at
+      # startup. Set a strong, persistent value only if you need sessions to
+      # survive restarts (the bundled UI currently uses no server-side sessions).
+      - SECRET_KEY=${SECRET_KEY:-}
       - HOST=0.0.0.0
       - PORT=5001
       # Security settings
@@ -32,8 +35,13 @@ services:
       - ENV_FILE=
       - GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      # slim image has no curl — use the Python stdlib instead
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/audit-2026-07/implementation-plan.md
+++ b/docs/audit-2026-07/implementation-plan.md
@@ -1,0 +1,81 @@
+# Audit 2026-07 — Architektur, Implementierung, UX, Security
+
+Konsolidierter Befund und Implementierungsplan aus einem Multi-Perspektiven-Audit
+(Backend/Architektur, Frontend/UX, Security/Ops, STRIDE).
+
+## Methodik & Scope
+Vier parallele Analysen des Projekts, jeweils gegen den Code auf Disk. Befunde
+wurden dedupliziert, im Code stichprobenartig verifiziert und nach
+Wert × Risiko × Abhängigkeit priorisiert.
+
+**Wichtige Einordnung:** Geprüft wurde teils der WIP-Branch
+`chore/security-hardening-and-deps` (Frontend), teils `main` (Backend/Ops/CI).
+Frontend-Dateien unterscheiden sich zwischen beiden — die fingierte
+Fortschritts-„Fassade" existiert **nur im WIP-Branch, nicht auf `main`**. Der
+Plan bezieht sich auf `main` als Zielzweig.
+
+**Bereits erledigt (nicht Teil des Plans):** Dependabot-Konsolidierung,
+Auto-Merge-Fix + Grouping, pytest-CI als Required Check, release-please.
+Offener Test-Backlog: #63.
+
+## Kernbild
+Die Web-/API-Schicht ist handwerklich solide (RESTful-Resources,
+Marshmallow-Validierung, Backoff-Mechanik, Log-Sanitizing). Durchgehendes
+Muster über alle Dimensionen: **polierte Oberfläche über nicht belastbarem
+Kern** — die einzige echte Zugriffskontrolle ist unbenutzbar, das CLI ist
+kaputt, und die zentrale Operation (Minuten-langes Multi-Device-Update) sprengt
+das eigene Betriebsmodell.
+
+## Was gut ist
+- SSRF/IDOR mitigiert: Endpoints verarbeiten nur in `devices.yaml` konfigurierte
+  IPs (Config-Match erzwungen); `is_valid_ip_address` blockt
+  loopback/link-local/metadata (169.254.169.254).
+- Constant-time API-Key-Vergleich, `yaml.safe_load`, Passwort-Maskierung,
+  `sanitize_log_data`, keine ReDoS-Regexes.
+- Non-root-Container + tini, Multi-Stage ohne gebackene Secrets.
+- CORS same-origin-Default; `SECRET_KEY` zufällig bei unset.
+- Frontend nutzt Alpine `x-text` (Auto-Escaping), kein `x-html`, keine Tokens im
+  `localStorage`.
+
+## Phasen (→ GitHub-Issues)
+
+### Phase 0 — Quick Wins · #68
+Risikoarme Korrektheits-/UX-/Härtungs-Fixes. **In Umsetzung / dieser PR.**
+404→404, Timeout-Handler-Crash (const-Scope), Mobile-Navbar, Doppel-Fehler,
+`:disabled`-Links, `[x-cloak]`, `window.open`-noopener, Security-Header +
+`MAX_CONTENT_LENGTH`, `hmac`-Bytes-Vergleich, Healthcheck ohne `curl`, schwacher
+`SECRET_KEY`-Default, Marshmallow-`Meta`-No-op, Container-Härtung.
+
+### Phase 1 — Zugriffskontrolle & CSRF · #69  🔴 höchster Sicherheitswert
+Auth fail-closed + UI sendet Key + `request.is_json`-Pflicht (CSRF) +
+Swagger/`/version` schützen + Audit-Logging. **Design/Brainstorm vorab.**
+
+### Phase 2 — Robustheit / DoS · #70
+Rate-Limiting (schnell) + async Batch (Job-Queue, `202`+Status-Endpoint) +
+`gunicorn.conf.py` im Container tatsächlich laden. **Design vorab.**
+
+### Phase 3 — Ehrliche UX & a11y · #71  (hängt an Phase 2)
+Echter Server-Fortschritt statt Fassade; Modal-a11y; Live-Batch-Balken;
+Concurrency-Limit; Bestätigungsdialog mit Geräteliste.
+
+### Phase 4 — CLI reparieren oder deprecaten · #72
+`tasmota_updater.py` ist durch Signatur-Mismatch + Doppel-Definitionen
+funktionsunfähig. Entscheidung: Kernfunktionen wiederverwenden **oder**
+deprecaten.
+
+### Phase 5 — Architektur & Wartbarkeit · #73
+`updater.py` entflechten; Cache-Locking über Worker; Excepts differenzieren;
+Verifikations-Korrektheit (200 ≠ Erfolg); Credentials via `HTTPBasicAuth`;
+Summary-Zählung.
+
+### Querschnitt — Threat-Model & Doku · #74
+`docs/threat-models/`; README (LAN-only, Klartext-HTTP-Restrisiko);
+Betreiber-Fragen (Reverse-Proxy? Internet-exponiert?) klären.
+
+## Empfohlene Reihenfolge
+Phase 0 → Phase 1 → (Threat-Model-Stub) → Phase 2 → Phase 3 → Phase 4 → Phase 5.
+
+## Blockierende Vorab-Fragen
+1. Exposition: strikt LAN-only oder Internet-erreichbar? (Severity Phase 1/2)
+2. Reverse-Proxy davor (TLS/CSP/Rate-Limit)?
+3. CLI: reparieren oder deprecaten?

--- a/server.py
+++ b/server.py
@@ -59,6 +59,7 @@ def create_app(test_config=None):
     # Load default configuration
     app.config.from_mapping(
         SECRET_KEY=secret_key,
+        MAX_CONTENT_LENGTH=int(os.environ.get('MAX_CONTENT_LENGTH', 64 * 1024)),
         DEVICES_FILE=os.environ.get('DEVICES_FILE', 'devices.yaml'),
         # Security settings
         SESSION_COOKIE_SECURE=os.environ.get('SESSION_COOKIE_SECURE', 'false').lower() in ('true', '1', 't'),
@@ -98,7 +99,7 @@ def create_app(test_config=None):
         def _require_api_key():
             if request.path.startswith('/api/'):
                 provided = request.headers.get('X-API-Key', '')
-                if not hmac.compare_digest(provided, api_key):
+                if not hmac.compare_digest(provided.encode('utf-8'), api_key.encode('utf-8')):
                     return jsonify({'error': 'Unauthorized'}), 401
         logger.info("API key authentication enabled for /api/* endpoints")
     else:
@@ -141,6 +142,16 @@ def create_app(test_config=None):
         """Health check endpoint for container orchestration"""
         return {"status": "healthy"}, 200
     
+    # Baseline security headers (defense-in-depth). A strict CSP is intentionally
+    # deferred until the CDN assets are self-hosted, since Alpine relies on
+    # inline expressions/handlers that a strict policy would break.
+    @app.after_request
+    def _security_headers(response):
+        response.headers.setdefault('X-Frame-Options', 'DENY')
+        response.headers.setdefault('X-Content-Type-Options', 'nosniff')
+        response.headers.setdefault('Referrer-Policy', 'no-referrer')
+        return response
+
     return app
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ergebnis des Architektur/UX/Security-Audits 2026-07: das konsolidierte Plan-Dokument **und** die Umsetzung von **Phase 0** (#68).

## 1. Plan-Dokument
`docs/audit-2026-07/implementation-plan.md` — Befund, „was gut ist", Phasen 0–5 + Querschnitt, verlinkt auf die Issues #68–#74.

## 2. Phase 0 — Quick Wins (Closes #68)

**Korrektheit**
- `api.py`: `POST /api/update` mit unbekannter IP gab **HTTP 200** (`jsonify` auf ein Tupel) → jetzt echtes **404**.
- `app.js`: Timeout-Handler crashte per `ReferenceError` (`const timeoutValue` im `try`, im `catch` genutzt) → bei Timeout **keine** Meldung. In 5 Funktionen vor den `try` gehoben.
- `api.py`: wirkungsloses `class Meta: required` entfernt.

**UX / a11y**
- `navbar-burger` ergänzt → Aktionsleiste auf Mobile erreichbar.
- doppelte Fehler-Notification entfernt.
- `.card-footer-item[disabled]` → `pointer-events:none` (deaktivierte Links waren klickbar).
- `[x-cloak]{display:none}` ergänzt (Alpine-CDN liefert es nicht) → kein FOUC.
- `window.open(...)` mit `'noopener'`.

**Härtung**
- Security-Header (X-Frame-Options/X-Content-Type-Options/Referrer-Policy) + `MAX_CONTENT_LENGTH`.
- `hmac.compare_digest` auf Bytes → kein 500 bei Non-ASCII-Header.
- Healthcheck ohne `curl` (Python-Stdlib) in `Containerfile` + `compose.example.yml`.
- schwacher `SECRET_KEY`-Default entfernt; `cap_drop:[ALL]` + `no-new-privileges`.

## Bewusst verschoben (mit Grund)
- **API_KEY verpflichtend → Phase 1 (#69):** bräche jetzt die UI (sendet noch keinen Key).
- **SRI / Image-Digest-Pin:** brauchen Netzzugriff (Corporate-Proxy blockt npm/CDN).
- **Strikte CSP:** bräche Alpine/CDN — kommt mit Self-Hosting.

## Verifikation
`py_compile` · `node --check app.js` · YAML valide · Runtime-Smoke (Header gesetzt, unbekannte IP→404, Index rendert mit Burger, `MAX_CONTENT_LENGTH`=64 KiB) · pytest-Kern **29 passed**.

## Scope-Hinweis
Geprüft/gefixt auf `main`. Die im Audit erwähnte fingierte Fortschritts-„Fassade" existiert nur im WIP-Branch `chore/security-hardening-and-deps`, nicht auf `main` — daher hier nicht enthalten (siehe #71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)