### PR TITLE
feat(security): fail-closed API auth via UI session cookie + CSRF hardening

### DIFF
--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -293,6 +293,9 @@ class DeviceUpdateResource(Resource):
         """
         # Validate request data
         schema = DeviceUpdateSchema()
+        if not request.is_json:
+            return {'error': 'Invalid request',
+                    'details': 'Content-Type must be application/json'}, 415
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             return {'error': 'Invalid request',
@@ -323,6 +326,10 @@ class DeviceUpdateResource(Resource):
                 current_app.logger.info(f"Using timeout override: {timeout}s for device {device_ip}")
 
             # Update device firmware with enhanced timeout handling
+            current_app.logger.info(
+                f"Firmware update requested for {device_ip} "
+                f"(check_only={check_only}) from {request.remote_addr}"
+            )
             result = update_device_firmware(device_config, check_only)
         else:
             return {'error': 'Device not found'}, 404
@@ -416,10 +423,18 @@ class AllDevicesUpdateResource(Resource):
         devices = load_devices_from_file(devices_file)
         
         # Extract parameters
+        if not request.is_json:
+            return {'error': 'Invalid request',
+                    'details': 'Content-Type must be application/json'}, 415
         payload = request.get_json(silent=True) or {}
         check_only = payload.get('check_only', False)
         update_only_needed = payload.get('update_only_needed', True)
         global_timeout = payload.get('timeout')
+
+        current_app.logger.info(
+            f"Batch firmware update requested (check_only={check_only}, "
+            f"update_only_needed={update_only_needed}) from {request.remote_addr}"
+        )
 
         if global_timeout is not None:
             if global_timeout < 60 or global_timeout > 600:

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -28,7 +28,13 @@ services:
       - HOST=0.0.0.0
       - PORT=5001
       # Security settings
-      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-true}
+      # Keep false for plain-HTTP LAN use, otherwise the browser drops the UI
+      # session cookie and the web UI can no longer reach the API. Set true only
+      # when serving behind HTTPS/TLS.
+      - SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-false}
+      # API_KEY is optional: the web UI authenticates via its session cookie.
+      # Set a strong API_KEY only to allow programmatic X-API-Key clients.
+      - API_KEY=${API_KEY:-}
       - SESSION_COOKIE_HTTPONLY=${SESSION_COOKIE_HTTPONLY:-true}
       - LOGGING_LEVEL=${LOGGING_LEVEL:-INFO}
       # No need to load .env in production container, use environment variables from compose.yml instead

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ import logging
 import secrets
 from pathlib import Path
 from dotenv import load_dotenv
-from flask import Flask, render_template, send_from_directory, jsonify, request
+from flask import Flask, render_template, send_from_directory, jsonify, request, session
 from flask_cors import CORS
 from flasgger import Swagger
 from app.tasmota.api import init_api
@@ -64,6 +64,7 @@ def create_app(test_config=None):
         # Security settings
         SESSION_COOKIE_SECURE=os.environ.get('SESSION_COOKIE_SECURE', 'false').lower() in ('true', '1', 't'),
         SESSION_COOKIE_HTTPONLY=os.environ.get('SESSION_COOKIE_HTTPONLY', 'true').lower() in ('true', '1', 't'),
+        SESSION_COOKIE_SAMESITE='Strict',
         SWAGGER={
             'title': 'Tasmota Updater API',
             'description': 'API for managing and updating Tasmota devices',
@@ -91,21 +92,32 @@ def create_app(test_config=None):
             "(set CORS_ORIGINS to allow cross-origin API clients)"
         )
 
-    # Optional API-key authentication for the REST API. When API_KEY is set,
-    # every /api/* request must present a matching X-API-Key header.
+    # Access control for the REST API (fail-closed). Every /api/* request must
+    # come from either the bundled same-origin UI (signed, HttpOnly,
+    # SameSite=Strict session cookie set on GET /) or a programmatic client
+    # presenting a valid X-API-Key. Requests with neither are rejected (401).
     api_key = os.environ.get('API_KEY', '').strip()
+
+    @app.before_request
+    def _require_api_auth():
+        if not request.path.startswith('/api/'):
+            return None
+        # 1) Browser UI: signed session cookie (SameSite=Strict → CSRF-safe).
+        if session.get('ui_authenticated'):
+            return None
+        # 2) Programmatic client: constant-time X-API-Key comparison.
+        if api_key:
+            provided = request.headers.get('X-API-Key', '')
+            if hmac.compare_digest(provided.encode('utf-8'), api_key.encode('utf-8')):
+                return None
+        return jsonify({'error': 'Unauthorized'}), 401
+
     if api_key:
-        @app.before_request
-        def _require_api_key():
-            if request.path.startswith('/api/'):
-                provided = request.headers.get('X-API-Key', '')
-                if not hmac.compare_digest(provided.encode('utf-8'), api_key.encode('utf-8')):
-                    return jsonify({'error': 'Unauthorized'}), 401
-        logger.info("API key authentication enabled for /api/* endpoints")
+        logger.info("API auth: UI session cookie or X-API-Key required for /api/*")
     else:
-        logger.warning(
-            "API_KEY is not set; the REST API is unauthenticated. "
-            "Set API_KEY to require an X-API-Key header for /api/* requests."
+        logger.info(
+            "API auth: UI session cookie required for /api/* "
+            "(set API_KEY to also allow programmatic X-API-Key clients)"
         )
     
     # Initialize Swagger
@@ -126,7 +138,11 @@ def create_app(test_config=None):
     # Main route
     @app.route('/')
     def index():
-        """Serve the main application page"""
+        """Serve the main application page and establish a UI session."""
+        # Mark this browser as an authenticated UI client. The cookie is signed
+        # (SECRET_KEY), HttpOnly and SameSite=Strict, so JavaScript cannot read
+        # it and a cross-site request will not send it (CSRF-safe).
+        session['ui_authenticated'] = True
         return render_template('index.html')
     
     # Favicon route

--- a/tests/e2e/test_auth_flow.py
+++ b/tests/e2e/test_auth_flow.py
@@ -1,0 +1,21 @@
+"""E2E: the UI session-cookie flow reaches the (gated) API end-to-end.
+
+After Phase 1, /api/* is fail-closed. This verifies the browser obtains the
+session cookie from GET / and then successfully calls the API with it — the
+device list AND a per-device status fetch both succeed.
+"""
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_ui_session_reaches_api(page: Page, app_server: str):
+    page.goto(app_server + "/")
+
+    # Device cards render → GET /api/devices succeeded with the session cookie.
+    expect(page.locator(".card").first).to_be_visible()
+
+    # A fake device's firmware version shows → GET /api/devices/<ip> also
+    # succeeded end-to-end through the cookie-gated API.
+    expect(page.get_by_text("Current Version:").first).to_be_visible(timeout=15000)

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -1,0 +1,61 @@
+"""Integration tests for the /api/* access-control gate (Phase 1).
+
+Exercises the fail-closed gate via the Flask test client: no auth → 401,
+UI session cookie → allowed, X-API-Key → allowed, non-JSON state change → 415.
+"""
+import pytest
+
+from server import create_app
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update(TESTING=True, DEVICES_FILE="devices-dev.yaml")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_api_blocked_without_session_or_key(client):
+    """No UI session and no API key → 401."""
+    resp = client.post("/api/update/all", json={"check_only": True})
+    assert resp.status_code == 401
+
+
+def test_ui_session_grants_api_access(client):
+    """GET / establishes the signed session cookie; /api/* is then allowed."""
+    client.get("/")  # sets the ui_authenticated session cookie
+    resp = client.get("/api/devices")
+    assert resp.status_code == 200
+
+
+def test_state_change_requires_json(client):
+    """A non-JSON POST to a state-changing endpoint is rejected (CSRF hardening)."""
+    client.get("/")  # authenticated UI session
+    resp = client.post("/api/update/all", data="check_only=true",
+                       content_type="application/x-www-form-urlencoded")
+    assert resp.status_code == 415
+
+
+def test_health_and_version_not_gated(client):
+    """Operational endpoints stay open (container healthcheck, version)."""
+    assert client.get("/health").status_code == 200
+    assert client.get("/version").status_code == 200
+
+
+def test_api_key_client(monkeypatch):
+    """With API_KEY set, a valid X-API-Key is accepted and a wrong/absent one is not."""
+    monkeypatch.setenv("API_KEY", "s3cret-test-key")
+    app = create_app()
+    app.config.update(TESTING=True, DEVICES_FILE="devices-dev.yaml")
+    client = app.test_client()
+
+    assert client.get("/api/devices",
+                      headers={"X-API-Key": "s3cret-test-key"}).status_code == 200
+    assert client.get("/api/devices",
+                      headers={"X-API-Key": "wrong"}).status_code == 401
+    assert client.get("/api/devices").status_code == 401


### PR DESCRIPTION
**Phase 1** (Closes #69) — behebt die fail-open destruktive API und schließt CSRF, ohne die mitgelieferte UI zu brechen. Modell: vertrauenswürdiges LAN, Fokus CSRF (per Brainstorm entschieden).

## Zugriffskontrolle (`server.py`)
- **`/api/*` fail-closed:** Zugriff nur mit **gültiger UI-Session** *oder* **gültigem `X-API-Key`**. Der alte „unauthenticated"-Warnpfad ist weg.
- **UI-Auth via Cookie:** `GET /` setzt ein signiertes, `HttpOnly`, `SameSite=Strict` Session-Cookie → same-origin-UI läuft **ohne JS-Änderung**, der Key landet nie in HTML/JS.
- `API_KEY` ist **optional** (nur für programmatische Clients).

## CSRF — mehrschichtig
- `SameSite=Strict` → Cross-Site-Requests senden das Cookie nicht.
- `X-API-Key` = Custom-Header → erzwingt CORS-Preflight.
- **`Content-Type: application/json` Pflicht** auf state-changing POSTs (sonst **415**) → killt den simple-form-POST-Vektor + den `get_json(silent=True) or {}`-Footgun.

## Weiteres
- Audit-Logging destruktiver Aktionen (Ziel-IP + `request.remote_addr`).
- `compose.example.yml`: `SESSION_COOKIE_SECURE` Default **false** (LAN-HTTP; sonst droppt der Browser das Cookie — `true` hinter TLS), `API_KEY` optional dokumentiert.

## Tests (Pyramide, pro Phase)
- **Integration** `tests/test_auth_gate.py`: 401 ohne Auth · Cookie erlaubt · X-API-Key erlaubt/abgelehnt · 415 bei Non-JSON · `/health`+`/version` offen.
- **E2E** `tests/e2e/test_auth_flow.py` (Playwright): Cookie-Flow end-to-end (Geräteliste + Status via cookie-gated API).

Lokal verifiziert: **Unit 34 passed**, **E2E 2 passed**.

## Bewusst nicht in Phase 1
Swagger/`/version`-Schutz (Info-Disclosure, Low, trusted LAN) → notiert. Vollständiges Login/Multi-User → nicht nötig fürs LAN-Modell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)