### PR TITLE
feat: async background jobs for batch device updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -44,7 +44,7 @@ ENV PATH="/opt/venv/bin:$PATH" \
     PORT=5001
 
 # Copy only necessary application files
-COPY server.py wsgi.py /app/
+COPY server.py wsgi.py gunicorn.conf.py /app/
 COPY app/ /app/app/
 
 # Create non-root user and set permissions
@@ -66,4 +66,4 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # Command to run the application with Gunicorn in production
 # Use shell form to allow environment variable substitution
-CMD gunicorn --bind 0.0.0.0:5001 --workers ${GUNICORN_WORKERS:-4} --access-logfile - --error-logfile - wsgi:app
+CMD gunicorn -c gunicorn.conf.py wsgi:app

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -280,189 +280,136 @@ function tasmotaApp() {
             }
         },
         
+        // Poll a background job until it reaches a terminal state, invoking
+        // onProgress(job) on each tick. Returns the final job snapshot.
+        async _pollJob(jobId, onProgress) {
+            while (true) {
+                const resp = await fetch(`/api/jobs/${jobId}`);
+                if (!resp.ok) {
+                    throw new Error(`Failed to poll job status: ${resp.statusText}`);
+                }
+                const job = await resp.json();
+                if (onProgress) onProgress(job);
+                if (job.status === 'completed' || job.status === 'error') {
+                    return job;
+                }
+                await new Promise(resolve => setTimeout(resolve, 1500));
+            }
+        },
+
         async updateAllDevices() {
             this.isUpdatingAll = true;
-            this.updateProgress = {
-                total: 0,
-                completed: 0,
-                inProgress: 0,
-                failed: 0,
-                percentage: 0
-            };
-            
-            // Get user preference for update filtering
-            const updateOnlyNeeded = localStorage.getItem('update_only_needed') !== 'false';
-            const timeoutValue = 60; // Default to 60 seconds for batch updates
+            this.error = '';
+            this.updateProgress = { total: 0, completed: 0, inProgress: 0, failed: 0, percentage: 0 };
 
+            const updateOnlyNeeded = localStorage.getItem('update_only_needed') !== 'false';
             try {
-                // First, mark all devices as pending update
+                // Mark candidate devices as pending update
                 this.devices.forEach(device => {
-                    if (updateOnlyNeeded && !device.update_status?.needs_update) {
-                        return;
-                    }
+                    if (updateOnlyNeeded && !device.update_status?.needs_update) return;
                     device.update_in_progress = true;
                     device.update_completed = false;
                     device.update_message = 'Pending update...';
-                    this.updateProgress.total++;
                 });
-                
-                // Create an AbortController
-                const controller = new AbortController();
-                
-                // Set up timeout
-                const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
-                
-                const response = await fetch('/api/update/all', {
+
+                // Start the background job (returns 202 + job id immediately)
+                const startResp = await fetch('/api/update/all', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        check_only: false,
-                        update_only_needed: updateOnlyNeeded
-                    }),
-                    signal: controller.signal
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ check_only: false, update_only_needed: updateOnlyNeeded })
                 });
-                
-                // Clear timeout since fetch completed
-                clearTimeout(timeoutId);
-                
-                if (!response.ok) {
-                    throw new Error(`Failed to update devices: ${response.statusText}`);
+                if (startResp.status === 409) {
+                    throw new Error('A batch operation is already in progress.');
                 }
-                
-                const result = await response.json();
-                
-                // Update progress information
-                // Get the count of devices that need updates or are being updated
-                this.updateProgress.total = result.summary.needs_update > 0 ? result.summary.needs_update : this.updateProgress.total;
-                
-                this.updateProgress = {
-                    total: this.updateProgress.total, // Use the count of devices that need updates
-                    completed: result.summary.updated,
-                    inProgress: result.results.filter(r => r.update_started && !r.update_completed).length,
-                    failed: result.results.filter(r => r.update_started && !r.success).length,
-                    percentage: this.updateProgress.total > 0 ? 
-                        Math.round((result.summary.updated / this.updateProgress.total) * 100) : 0
-                };
-                
-                // Update the status of each device
-                result.results.forEach(updateResult => {
-                    const device = this.devices.find(d => d.ip === updateResult.ip);
-                    if (device) {
-                        device.update_status = updateResult;
-                        device.update_in_progress = updateResult.update_started && !updateResult.update_completed;
-                        device.update_completed = updateResult.update_completed;
-                        device.update_message = updateResult.message;
-                        
-                        // Add timeout information
-                        if (updateResult.timeout_seconds) {
-                            device.timeout_seconds = updateResult.timeout_seconds;
+                if (startResp.status !== 202 && !startResp.ok) {
+                    throw new Error(`Failed to start update: ${startResp.statusText}`);
+                }
+                const { job_id } = await startResp.json();
+
+                // Poll for real server-side progress
+                const job = await this._pollJob(job_id, (j) => {
+                    const total = j.total || 0;
+                    const completed = j.completed || 0;
+                    this.updateProgress = {
+                        total,
+                        completed,
+                        inProgress: Math.max(0, total - completed),
+                        failed: j.failed || 0,
+                        percentage: total > 0 ? Math.round((completed / total) * 100) : 0
+                    };
+                    (j.results || []).forEach(r => {
+                        const device = this.devices.find(d => d.ip === r.ip);
+                        if (device) {
+                            device.update_status = r;
+                            device.update_in_progress = r.update_started && !r.update_completed;
+                            device.update_completed = r.update_completed;
+                            device.update_message = r.message;
                         }
-                    }
+                    });
                 });
-                
-                // Show success message with summary
-                this.success = `Update completed: ${result.summary.updated} devices updated, ` + 
-                              `${result.summary.needs_update - result.summary.updated} devices failed or timed out.`;
-                
-                // Refresh device statuses after a delay
-                setTimeout(() => this.refreshDevices(), 5000);
+
+                if (job.status === 'error') {
+                    throw new Error(job.error || 'Batch update failed');
+                }
+                const summary = job.summary || { updated: 0, needs_update: 0 };
+                const failed = Math.max(0, (summary.needs_update || 0) - (summary.updated || 0));
+                this.success = `Update completed: ${summary.updated || 0} device(s) updated`
+                    + (failed ? `, ${failed} failed or skipped.` : '.');
+
+                setTimeout(() => this.refreshDevices(), 3000);
             } catch (error) {
                 console.error('Error updating all devices:', error);
-                
-                if (error.name === 'AbortError') {
-                    console.error(`Batch update operation timed out after ${timeoutValue}s`);
-                    this.error = `Batch update operation timed out after ${timeoutValue}s. Individual device updates may still be in progress.`;
-                } else {
-                    this.error = `Failed to update devices: ${error.message}`;
-                }
-                
-                // Reset update progress status for all devices
-                this.devices.forEach(device => {
-                    device.update_in_progress = false;
-                });
+                this.error = `Failed to update devices: ${error.message}`;
+                this.devices.forEach(device => { device.update_in_progress = false; });
             } finally {
                 this.isUpdatingAll = false;
             }
         },
-        
+
         async checkAllDevices() {
             this.isCheckingAll = true;
-            
-            // Set all devices to checking state
-            this.devices.forEach(device => {
-                device.isChecking = true;
-            });
-            
-            const timeoutValue = 60; // Default to 60 seconds for batch checks
+            this.error = '';
+            this.devices.forEach(device => { device.isChecking = true; });
+
             try {
-                // Create an AbortController
-                const controller = new AbortController();
-                
-                // Set up timeout
-                const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
-                
-                const response = await fetch('/api/update/all', {
+                const startResp = await fetch('/api/update/all', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        check_only: true
-                    }),
-                    signal: controller.signal
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ check_only: true })
                 });
-                
-                // Clear timeout since fetch completed
-                clearTimeout(timeoutId);
-                
-                if (!response.ok) {
-                    throw new Error(`Failed to check devices: ${response.statusText}`);
+                if (startResp.status === 409) {
+                    throw new Error('A batch operation is already in progress.');
                 }
-                
-                const result = await response.json();
+                if (startResp.status !== 202 && !startResp.ok) {
+                    throw new Error(`Failed to start check: ${startResp.statusText}`);
+                }
+                const { job_id } = await startResp.json();
+
+                const job = await this._pollJob(job_id);
+                if (job.status === 'error') {
+                    throw new Error(job.error || 'Batch check failed');
+                }
+
                 const currentTime = new Intl.DateTimeFormat(navigator.language, {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    second: '2-digit'
+                    hour: '2-digit', minute: '2-digit', second: '2-digit'
                 }).format(new Date());
-                
-                // Update the status of each device
-                result.results.forEach(updateResult => {
-                    const device = this.devices.find(d => d.ip === updateResult.ip);
+                (job.results || []).forEach(r => {
+                    const device = this.devices.find(d => d.ip === r.ip);
                     if (device) {
-                        device.update_status = updateResult;
+                        device.update_status = r;
                         device.lastChecked = currentTime;
                     }
                 });
-                
-                // Set success indicator for all devices
-                this.devices.forEach(device => {
-                    device.checkSuccess = true;
-                });
-                
-                // Clear success indicator after delay
+
+                this.devices.forEach(device => { device.checkSuccess = true; });
                 setTimeout(() => {
-                    this.devices.forEach(device => {
-                        device.checkSuccess = false;
-                    });
+                    this.devices.forEach(device => { device.checkSuccess = false; });
                 }, 2000);
-                
             } catch (error) {
                 console.error('Error checking all devices:', error);
-                
-                if (error.name === 'AbortError') {
-                    console.error(`Batch check operation timed out after ${timeoutValue}s`);
-                    this.error = `Batch check operation timed out after ${timeoutValue}s. Some devices may not have been checked.`;
-                } else {
-                    this.error = `Failed to check devices: ${error.message}`;
-                }
+                this.error = `Failed to check devices: ${error.message}`;
             } finally {
-                // Clear checking state for all devices
-                this.devices.forEach(device => {
-                    device.isChecking = false;
-                });
+                this.devices.forEach(device => { device.isChecking = false; });
                 this.isCheckingAll = false;
             }
         },

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -12,6 +12,7 @@ from app.tasmota.updater import (
     is_valid_ip_address,
 )
 from app.tasmota.utils import load_devices_from_file, resolve_dns_name, is_fake_device
+from app.tasmota import jobs
 
 
 # Schema definitions for request/response validation
@@ -441,69 +442,53 @@ class AllDevicesUpdateResource(Resource):
                 return {'error': 'Global timeout must be between 60 and 600 seconds'}, 400
             current_app.logger.info(f"Using global timeout override: {global_timeout}s for all devices")
         
-        # First check which devices need updates
-        if update_only_needed and not check_only:
-            check_results = []
-            for device in devices:
-                # Create a copy of the device config
-                device_config = device.copy()
-                result = update_device_firmware(device_config, check_only=True)
-                check_results.append(result)
-            
-            # Filter devices that need updates
-            devices_to_update = []
-            for i, result in enumerate(check_results):
-                if result.get('needs_update', False):
-                    devices_to_update.append(devices[i])
-        else:
-            devices_to_update = devices
-        
-        # Update devices that need updates
-        results = []
-        updated_count = 0
-        
-        for device in devices_to_update:
-            # Create a copy of the device config
-            device_config = device.copy()
+        # Run the (potentially minutes-long) batch on a background thread and
+        # return immediately; the client polls GET /api/jobs/<id> for progress.
+        # This frees the worker and avoids the Gunicorn request timeout.
+        job_id = jobs.create_batch_job(
+            devices, check_only, update_only_needed, global_timeout
+        )
+        if job_id is None:
+            return {'error': 'A batch update is already in progress'}, 409
+        return {'job_id': job_id, 'status_url': f'/api/jobs/{job_id}'}, 202
 
-            # Apply global timeout override if provided
-            if global_timeout is not None:
-                device_config['timeout'] = global_timeout
 
-            result = update_device_firmware(device_config, check_only)
-            
-            # Add additional status fields
-            result['update_started'] = not check_only and (result.get('needs_update', False) or not update_only_needed)
-            result['update_completed'] = result['success'] and result['update_started']
-            
-            if result['update_completed']:
-                updated_count += 1
-                
-            results.append(result)
-        
-        # Generate summary
-        summary = {
-            'total': len(devices),
-            'success': sum(1 for r in results if r['success']),
-            'needs_update': sum(1 for r in results if r.get('needs_update', False)),
-            'updated': updated_count
-        }
-        
-        return jsonify({
-            'results': results,
-            'summary': summary
-        })
+class JobResource(Resource):
+    """Resource for polling the status/results of a background job."""
+
+    def get(self, job_id):
+        """
+        Get the status and (partial) results of a background job
+        ---
+        tags:
+          - updates
+        parameters:
+          - in: path
+            name: job_id
+            type: string
+            required: true
+        responses:
+          200:
+            description: Job status, progress and results
+          404:
+            description: Job not found
+        """
+        job = jobs.get_job(job_id)
+        if job is None:
+            return {'error': 'Job not found'}, 404
+        return job
 
 
 def init_api(app):
     """Initialize API routes"""
     api = Api(app)
-    
+
     # Register resources
     api.add_resource(DeviceListResource, '/api/devices')
     api.add_resource(DeviceStatusResource, '/api/devices/<string:device_ip>')
     api.add_resource(LatestReleaseResource, '/api/releases/latest')
     api.add_resource(DeviceUpdateResource, '/api/update')
     api.add_resource(AllDevicesUpdateResource, '/api/update/all')
-    
+    api.add_resource(JobResource, '/api/jobs/<string:job_id>')
+
     return api

--- a/app/tasmota/jobs.py
+++ b/app/tasmota/jobs.py
@@ -1,0 +1,172 @@
+"""In-memory background job runner for long-running batch firmware updates.
+
+A batch firmware update can take minutes per device. Running it inside the HTTP
+request blocks a worker for the whole batch and trips the Gunicorn request
+timeout. Instead, the API creates a job here, runs it on a background thread and
+returns ``202 Accepted`` immediately; clients poll ``GET /api/jobs/<id>`` for
+progress and results.
+
+Job state lives in this process's memory, guarded by a lock. This assumes a
+single Gunicorn worker (see ``gunicorn.conf.py``); scaling to multiple workers
+would require a shared store (e.g. Redis).
+"""
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+from app.tasmota.updater import update_device_firmware
+
+_lock = threading.Lock()
+_jobs: Dict[str, Dict[str, Any]] = {}
+
+# Keep at most this many finished jobs around (small LAN tool; avoid unbounded growth).
+_MAX_JOBS = 50
+
+
+def _snapshot(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy safe to serialise outside the lock."""
+    snap = dict(job)
+    snap["results"] = list(job["results"])
+    return snap
+
+
+def get_job(job_id: str) -> Optional[Dict[str, Any]]:
+    """Return a serialisable snapshot of a job, or None if unknown."""
+    with _lock:
+        job = _jobs.get(job_id)
+        return _snapshot(job) if job else None
+
+
+def batch_in_progress() -> bool:
+    with _lock:
+        return any(j["status"] in ("pending", "running") for j in _jobs.values())
+
+
+def _prune_locked() -> None:
+    if len(_jobs) <= _MAX_JOBS:
+        return
+    finished = [
+        (jid, j) for jid, j in _jobs.items()
+        if j["status"] in ("completed", "error")
+    ]
+    finished.sort(key=lambda kv: kv[1].get("finished_at") or 0)
+    for jid, _ in finished[: len(_jobs) - _MAX_JOBS]:
+        _jobs.pop(jid, None)
+
+
+def create_batch_job(
+    devices: List[Dict[str, Any]],
+    check_only: bool,
+    update_only_needed: bool,
+    global_timeout: Optional[int],
+    *,
+    updater: Optional[Callable[..., Dict[str, Any]]] = None,
+    clock: Callable[[], float] = time.time,
+    background: bool = True,
+) -> Optional[str]:
+    """Create and start a batch job. Returns the job id, or None if one is already running.
+
+    ``updater``/``clock``/``background`` are injectable to keep the runner testable.
+    The updater defaults to the module-level ``update_device_firmware`` resolved at
+    call time (so it can be monkeypatched in tests).
+    """
+    resolved_updater = updater or update_device_firmware
+    with _lock:
+        if any(j["status"] in ("pending", "running") for j in _jobs.values()):
+            return None
+        job_id = uuid.uuid4().hex
+        _jobs[job_id] = {
+            "job_id": job_id,
+            "status": "pending",
+            "check_only": bool(check_only),
+            "total": 0,
+            "completed": 0,
+            "failed": 0,
+            "results": [],
+            "summary": None,
+            "error": None,
+            "created_at": clock(),
+            "finished_at": None,
+        }
+        _prune_locked()
+
+    if background:
+        threading.Thread(
+            target=_run_batch,
+            args=(job_id, devices, check_only, update_only_needed, global_timeout, resolved_updater, clock),
+            daemon=True,
+        ).start()
+    else:
+        _run_batch(job_id, devices, check_only, update_only_needed, global_timeout, resolved_updater, clock)
+    return job_id
+
+
+def _set(job_id: str, **fields: Any) -> None:
+    with _lock:
+        job = _jobs.get(job_id)
+        if job is not None:
+            job.update(fields)
+
+
+def _run_batch(
+    job_id: str,
+    devices: List[Dict[str, Any]],
+    check_only: bool,
+    update_only_needed: bool,
+    global_timeout: Optional[int],
+    updater: Callable[..., Dict[str, Any]],
+    clock: Callable[[], float],
+) -> None:
+    try:
+        _set(job_id, status="running")
+
+        # Determine which devices to process (mirrors the previous sync endpoint).
+        if update_only_needed and not check_only:
+            devices_to_process = [
+                d for d in devices
+                if updater(d.copy(), check_only=True).get("needs_update", False)
+            ]
+        else:
+            devices_to_process = list(devices)
+        _set(job_id, total=len(devices_to_process))
+
+        results: List[Dict[str, Any]] = []
+        updated = 0
+        for device in devices_to_process:
+            config = device.copy()
+            if global_timeout is not None:
+                config["timeout"] = global_timeout
+            result = updater(config, check_only)
+            result["update_started"] = (
+                not check_only and (result.get("needs_update", False) or not update_only_needed)
+            )
+            result["update_completed"] = bool(result.get("success")) and result["update_started"]
+            if result["update_completed"]:
+                updated += 1
+            results.append(result)
+            with _lock:
+                job = _jobs.get(job_id)
+                if job is not None:
+                    job["completed"] = len(results)
+                    job["failed"] = sum(
+                        1 for r in results if r.get("update_started") and not r.get("success")
+                    )
+                    job["results"] = list(results)
+
+        summary = {
+            "total": len(devices),
+            "processed": len(devices_to_process),
+            "success": sum(1 for r in results if r.get("success")),
+            "needs_update": sum(1 for r in results if r.get("needs_update", False)),
+            "updated": updated,
+        }
+        _set(job_id, status="completed", summary=summary, finished_at=clock())
+    except Exception as exc:  # pragma: no cover - defensive; surfaced to the client
+        _set(job_id, status="error", error=str(exc), finished_at=clock())
+
+
+def _reset_for_tests() -> None:
+    """Clear all job state (test helper)."""
+    with _lock:
+        _jobs.clear()

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,25 @@
+"""Gunicorn configuration for the Tasmota Updater.
+
+Uses a threaded worker so slow, blocking device I/O does not exhaust processes,
+and a single worker so the in-memory background-job store (app/tasmota/jobs.py)
+stays consistent across the request that starts a batch and the requests that
+poll it. Scaling to multiple workers would require a shared job store.
+"""
+import os
+
+bind = f"0.0.0.0:{os.environ.get('PORT', '5001')}"
+
+# One worker keeps the in-memory job registry consistent; threads provide
+# concurrency for the (mostly I/O-bound) request handlers.
+workers = int(os.environ.get("GUNICORN_WORKERS", "1"))
+worker_class = "gthread"
+threads = int(os.environ.get("GUNICORN_THREADS", "8"))
+
+# Batch updates run in a background thread and return 202 immediately, so they
+# are not bound by this. A single synchronous device update can still run for
+# minutes, so keep the request timeout above the maximum device timeout (600s).
+timeout = int(os.environ.get("GUNICORN_TIMEOUT", "700"))
+graceful_timeout = int(os.environ.get("GUNICORN_GRACEFUL_TIMEOUT", "30"))
+
+accesslog = "-"
+errorlog = "-"

--- a/tests/e2e/test_update_flow.py
+++ b/tests/e2e/test_update_flow.py
@@ -1,0 +1,25 @@
+"""E2E: the async batch flow (Phase 2) works end-to-end from the browser.
+
+Clicking "Check All" starts a background job (202), the UI polls it, and the
+per-device results land — exercising POST /api/update/all → GET /api/jobs/<id>
+through the cookie-gated API with fake devices.
+"""
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_check_all_async_flow(page: Page, app_server: str):
+    page.goto(app_server + "/")
+    expect(page.locator(".card").first).to_be_visible()
+
+    page.get_by_role("button", name="Check All").click()
+
+    # The polled job completes and per-device "Last:" checked timestamps appear
+    # (proves 202 → poll → results end-to-end). Generous timeout: the check may
+    # fetch the latest release upstream.
+    expect(page.get_by_text("Last:").first).to_be_visible(timeout=30000)
+
+    # No error notification surfaced during the async flow.
+    expect(page.locator(".notification.is-danger")).not_to_be_visible()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,87 @@
+"""Unit tests for the background batch-job runner (Phase 2)."""
+import threading
+
+import pytest
+
+from app.tasmota import jobs
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    jobs._reset_for_tests()
+    yield
+    jobs._reset_for_tests()
+
+
+def _canned(results_by_ip):
+    def _updater(config, check_only=False):
+        return dict(results_by_ip[config["ip"]])
+    return _updater
+
+
+def test_batch_runs_and_summarises_synchronously():
+    devices = [{"ip": "a"}, {"ip": "b"}]
+    results = {
+        "a": {"ip": "a", "success": True, "needs_update": True},
+        "b": {"ip": "b", "success": True, "needs_update": False},
+    }
+    job_id = jobs.create_batch_job(
+        devices, check_only=False, update_only_needed=False, global_timeout=None,
+        updater=_canned(results), clock=lambda: 1.0, background=False,
+    )
+    job = jobs.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["total"] == 2
+    assert job["completed"] == 2
+    # update_only_needed=False → every device is "started"; both succeed → both updated
+    assert job["summary"]["updated"] == 2
+    assert len(job["results"]) == 2
+
+
+def test_update_only_needed_filters_via_precheck():
+    devices = [{"ip": "a"}, {"ip": "b"}]
+    results = {
+        "a": {"ip": "a", "success": True, "needs_update": True},
+        "b": {"ip": "b", "success": True, "needs_update": False},
+    }
+    job_id = jobs.create_batch_job(
+        devices, check_only=False, update_only_needed=True, global_timeout=None,
+        updater=_canned(results), clock=lambda: 1.0, background=False,
+    )
+    job = jobs.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["total"] == 1          # only "a" needed an update
+    assert job["summary"]["updated"] == 1
+
+
+def test_runner_records_updater_exception():
+    def boom(config, check_only=False):
+        raise RuntimeError("device exploded")
+    job_id = jobs.create_batch_job(
+        [{"ip": "a"}], check_only=False, update_only_needed=False, global_timeout=None,
+        updater=boom, clock=lambda: 1.0, background=False,
+    )
+    job = jobs.get_job(job_id)
+    assert job["status"] == "error"
+    assert "device exploded" in job["error"]
+
+
+def test_only_one_batch_at_a_time():
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow(config, check_only=False):
+        started.set()
+        release.wait(timeout=5)
+        return {"ip": config["ip"], "success": True, "needs_update": False}
+
+    first = jobs.create_batch_job([{"ip": "a"}], False, False, None, updater=slow, background=True)
+    assert started.wait(timeout=5)
+    second = jobs.create_batch_job([{"ip": "b"}], False, False, None, background=True)
+    assert first is not None
+    assert second is None  # guard rejects a concurrent batch
+    release.set()
+
+
+def test_unknown_job_is_none():
+    assert jobs.get_job("nope") is None

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,0 +1,83 @@
+"""Integration tests: async batch jobs via the API (Phase 2).
+
+The updater is monkeypatched to a fast stub so these stay deterministic and
+offline (no GitHub release lookup / device I/O).
+"""
+import time
+
+import pytest
+
+from server import create_app
+from app.tasmota import jobs
+
+
+@pytest.fixture
+def client(monkeypatch):
+    jobs._reset_for_tests()
+
+    def fast_updater(config, check_only=False):
+        return {"ip": config["ip"], "success": True, "needs_update": True,
+                "message": "stub", "current_version": "1.0", "latest_version": "1.1"}
+
+    monkeypatch.setattr("app.tasmota.jobs.update_device_firmware", fast_updater)
+
+    app = create_app()
+    app.config.update(TESTING=True, DEVICES_FILE="devices-dev.yaml")
+    c = app.test_client()
+    c.get("/")  # establish the authenticated UI session (Phase 1 gate)
+    yield c
+    jobs._reset_for_tests()
+
+
+def _wait_for_job(client, job_id, timeout=15.0):
+    deadline = time.time() + timeout
+    job = None
+    while time.time() < deadline:
+        job = client.get(f"/api/jobs/{job_id}").get_json()
+        if job["status"] in ("completed", "error"):
+            return job
+        time.sleep(0.05)
+    return job
+
+
+def test_batch_update_returns_202_and_completes(client):
+    resp = client.post("/api/update/all", json={"check_only": False, "update_only_needed": True})
+    assert resp.status_code == 202
+    job_id = resp.get_json()["job_id"]
+
+    job = _wait_for_job(client, job_id)
+    assert job["status"] == "completed"
+    assert job["total"] >= 1
+    assert len(job["results"]) == job["total"]
+    assert job["summary"]["updated"] == job["total"]
+
+
+def test_second_batch_while_running_conflicts(client, monkeypatch):
+    # Make the updater slow so the first job stays 'running'.
+    import threading
+    release = threading.Event()
+
+    def slow_updater(config, check_only=False):
+        release.wait(timeout=5)
+        return {"ip": config["ip"], "success": True, "needs_update": False}
+
+    monkeypatch.setattr("app.tasmota.jobs.update_device_firmware", slow_updater)
+
+    first = client.post("/api/update/all", json={"check_only": True})
+    assert first.status_code == 202
+    second = client.post("/api/update/all", json={"check_only": True})
+    assert second.status_code == 409
+    release.set()
+
+
+def test_unknown_job_returns_404(client):
+    assert client.get("/api/jobs/does-not-exist").status_code == 404
+
+
+def test_jobs_endpoint_requires_auth():
+    """Without a UI session or API key, the jobs endpoint is gated too."""
+    jobs._reset_for_tests()
+    app = create_app()
+    app.config.update(TESTING=True, DEVICES_FILE="devices-dev.yaml")
+    unauth = app.test_client()  # no GET / → no session
+    assert unauth.get("/api/jobs/whatever").status_code == 401


### PR DESCRIPTION
**Phase 2** (Closes #70) — behebt Worker-Starvation/Timeout bei Batch-Updates und legt die Grundlage für echten Fortschritt (Phase 3, #71).

## Problem
`POST /api/update/all` lief die Geräte **synchron** in einem Request durch (Minuten pro Gerät) → blockierter Worker, Gunicorn-Timeout-Kill. Zusatzfund: der Container-`CMD` nutzte inline `gunicorn --workers 4` **ohne `--timeout` → Default 30s**, `gunicorn.conf.py` existierte gar nicht auf `main`. Real-Updates wurden also nach 30s gekillt.

## Lösung
**Backend**
- `app/tasmota/jobs.py` — thread-safe In-memory-Job-Runner; Batch läuft im Hintergrund-Thread; Guard: nur ein aktiver Batch (sonst **409**).
- `api.py` — `POST /api/update/all` → **`202 {job_id, status_url}`**; neuer **`GET /api/jobs/<id>`** (Status/Fortschritt/Ergebnisse).
- `gunicorn.conf.py` (**neu**) — `gthread`, **1 Worker** (konsistenter In-memory-Store), `timeout=700`. `Containerfile` lädt jetzt `-c gunicorn.conf.py`.

**Frontend** (`app.js`)
- `updateAllDevices`/`checkAllDevices` pollen den Job (`_pollJob`) → **echter** Fortschritt (ersetzt den 0→100-Sprung).

## Bewusst später
Single `POST /api/update` bleibt synchron (auf ein Gerät begrenzt) — Follow-up. `flask-limiter`/Rate-Limit später (der Async-Guard deckt den Kern-DoS ab).

## Tests (Pyramide)
- **Unit** `test_jobs.py`: Runner, Filter, Exception, Ein-Batch-Guard.
- **Integration** `test_jobs_api.py`: 202 → Poll → completed · 409 · 404 · Auth-Gate.
- **E2E** `test_update_flow.py`: „Check All" async-Flow im Browser (Fake-Devices).

Lokal verifiziert: **43 unit/integration + 3 e2e** grün.

## Betriebs-Hinweis
Der In-memory-Job-Store setzt **einen** Worker voraus (in `gunicorn.conf.py` so gesetzt). Mehr Worker bräuchten einen Shared Store (Redis) — dokumentiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)