### PR TITLE
fix(ui): refresh device card after a successful update

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -256,8 +256,11 @@ function tasmotaApp() {
                     if (device.fake) {
                         await new Promise(resolve => setTimeout(resolve, 3000));
                     }
-                    // Check update status again
-                    await this.checkDeviceUpdate(device);
+                    // Re-fetch the full device status so the card shows the new
+                    // firmware version and re-evaluates the "Update Available" tag
+                    // (checkDeviceUpdate alone updates update_status but not
+                    // device.status.version, leaving a stale version on the card).
+                    await this.fetchDeviceStatus(device);
                 } else {
                     // Update failed
                     device.update_message = device.update_status.message || 'Update failed';

--- a/tests/e2e/test_update_refreshes_card.py
+++ b/tests/e2e/test_update_refreshes_card.py
@@ -1,0 +1,29 @@
+"""Regression E2E: after a single-device update the card must re-fetch the
+device status (GET /api/devices/<ip>), so the shown firmware version updates
+and the "Update Available" tag clears — not just a re-check.
+"""
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def test_single_update_refetches_device_status(page: Page, app_server: str):
+    page.goto(app_server + "/")
+    card = page.locator(".card").first
+    expect(card).to_be_visible()
+
+    # Wait until the first device has been checked and needs an update
+    # (this enables its "Update" action).
+    expect(card.get_by_text("Update Available")).to_be_visible(timeout=30000)
+
+    # The post-update status refetch (GET /api/devices/<ip>) is what refreshes the
+    # shown version; on fake devices it lags the success indicator, so wait for it.
+    with page.expect_request(
+        lambda r: r.method == "GET" and "/api/devices/" in r.url,
+        timeout=20000,
+    ):
+        card.locator(".card-footer-item").filter(has_text="Update").click()
+        page.get_by_role("button", name="Update", exact=True).click()  # confirm modal
+
+    expect(page.get_by_text("Update completed successfully").first).to_be_visible(timeout=10000)


### PR DESCRIPTION
## Bug
Nach einem erfolgreichen **Einzel-Update** blieb auf der Gerätekarte die alte `Current Version` stehen und der **„Update Available"**-Tag verschwand nicht — obwohl „Update completed successfully" angezeigt wurde. *(Screenshot vom Maintainer.)*

## Ursache
`updateDevice()` rief im Erfolgszweig nur `checkDeviceUpdate(device)` auf — das aktualisiert `device.update_status`, **nicht** `device.status.version` (woran die Karte „Current Version" bindet). Die angezeigte Version blieb daher der Vor-Update-Stand.

## Fix
Im Erfolgszweig `checkDeviceUpdate` → **`fetchDeviceStatus`** (holt den frischen Geräte-Status inkl. neuer Version **und** ruft intern `checkDeviceUpdate` → Tag wird korrekt neu bewertet). Einzeiler; der Batch-Pfad war über `refreshDevices()` bereits korrekt.

## Test (TDD)
`tests/e2e/test_update_refreshes_card.py`: klickt Update auf einem Fake-Gerät und erwartet danach ein `GET /api/devices/<ip>`. **Verifiziert:** schlägt gegen den alten Code fehl, ist mit dem Fix grün. Gesamt lokal: 4 e2e + 44 unit/integration grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)