### PR TITLE
fix: verify the new firmware version before reporting update success

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -211,13 +211,19 @@ function tasmotaApp() {
             
             // Set update in progress flags for UI indicator
             device.update_in_progress = true;
+            device.update_completed = false;
+            device.update_verified = true;
+            device.update_result_message = '';
             device.update_message = 'Pending update...';
-            
+
             try {
                 // Create an AbortController
+                // The server waits for the device to actually report the new firmware
+                // version before answering, so it may take up to its full total_timeout
+                // (backend default 240s). Stay above that or we abort a running update.
                 const controller = new AbortController();
-                const timeoutValue = device.timeout || 60; // Default to 60 seconds for firmware updates
-                
+                const timeoutValue = (device.timeout || 240) + 30;
+
                 // Set up timeout
                 const timeoutId = setTimeout(() => controller.abort(), timeoutValue * 1000);
                 
@@ -248,10 +254,10 @@ function tasmotaApp() {
                 }
                 
                 if (device.update_status.success) {
-                    // Update was successful, set completed status
+                    // The server only reports success once the device reports a new
+                    // firmware version, so the restart has already happened here.
                     device.update_completed = true;
-                    // if update_status.message is not empty, use it, otherwise use default message, always append "Pending restart..."
-                    device.update_message = device.update_status.message ? device.update_status.message + ', pending restart...' : 'Update completed, pending restart...';
+                    device.update_message = device.update_status.message || 'Update completed successfully';
                     // if it is a fake device, sleep 3 seconds
                     if (device.fake) {
                         await new Promise(resolve => setTimeout(resolve, 3000));
@@ -261,6 +267,17 @@ function tasmotaApp() {
                     // (checkDeviceUpdate alone updates update_status but not
                     // device.status.version, leaving a stale version on the card).
                     await this.fetchDeviceStatus(device);
+
+                    // Never show a success message next to an "Update Available" tag.
+                    // The server verifies the new version before reporting success, so
+                    // this only trips if the device reports something unexpected.
+                    // Fake devices are exempt: their simulated update never changes the
+                    // reported version, so they always still "need" an update.
+                    if (!device.fake && device.update_status && device.update_status.needs_update) {
+                        device.update_verified = false;
+                        device.update_result_message =
+                            'Update reported as successful, but the device still offers an update — please re-check';
+                    }
                 } else {
                     // Update failed
                     device.update_message = device.update_status.message || 'Update failed';
@@ -312,6 +329,8 @@ function tasmotaApp() {
                     if (updateOnlyNeeded && !device.update_status?.needs_update) return;
                     device.update_in_progress = true;
                     device.update_completed = false;
+                    device.update_verified = true;
+                    device.update_result_message = '';
                     device.update_message = 'Pending update...';
                 });
 

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -287,6 +287,27 @@ class DeviceUpdateResource(Resource):
                     error_type:
                       type: string
                       description: Type of error encountered
+                version_verification:
+                  type: object
+                  description: >
+                    Result of verifying that the device actually runs a new firmware
+                    version after the update. Reachability alone is not proof of a
+                    completed update, so success is only reported once the reported
+                    version changed. error_type is "version_unchanged" when the device
+                    came back online but kept reporting the previous version.
+                  properties:
+                    elapsed_time:
+                      type: number
+                      description: Time spent waiting for the version to change
+                    attempts:
+                      type: integer
+                      description: Number of version reads performed
+                    timed_out:
+                      type: boolean
+                      description: Whether the version never changed in time
+                    error_type:
+                      type: string
+                      description: '"none" or "version_unchanged"'
           400:
             description: Invalid request
           500:

--- a/app/tasmota/updater.py
+++ b/app/tasmota/updater.py
@@ -444,6 +444,28 @@ def verify_device_restart_with_backoff(
     )
 
 
+def log_safe_address(ip_address: Any) -> str:
+    """
+    Normalize a device address for log output
+
+    Devices are addressed by IP — build_device_url() rejects anything else — so the
+    value is re-created from a validated ipaddress object instead of being taken
+    straight out of the device configuration. That normalizes the representation,
+    prevents a crafted address from forging log lines, and keeps the
+    credential-bearing device_config out of the logging data flow.
+
+    Args:
+        ip_address: Address as configured for the device
+
+    Returns:
+        Normalized address, or a placeholder if it is not a valid IP
+    """
+    try:
+        return format(ipaddress.ip_address(str(ip_address).strip()))
+    except ValueError:
+        return '<invalid-address>'
+
+
 def verify_firmware_version_changed(
     device_config: Dict[str, Any],
     previous_version: str,
@@ -472,7 +494,7 @@ def verify_firmware_version_changed(
         - new_firmware_info: Firmware info dict once the version changed, else None
         - timeout_report: Details about the verification process
     """
-    ip_address = device_config['ip']
+    ip_address = log_safe_address(device_config['ip'])
     start_time = time.time()
 
     if deadline is None:

--- a/app/tasmota/updater.py
+++ b/app/tasmota/updater.py
@@ -444,6 +444,116 @@ def verify_device_restart_with_backoff(
     )
 
 
+def verify_firmware_version_changed(
+    device_config: Dict[str, Any],
+    previous_version: str,
+    timeout_config: TimeoutConfig,
+    deadline: Optional[float] = None
+) -> Tuple[Optional[Dict[str, Any]], TimeoutReport]:
+    """
+    Verify that the device actually runs a different firmware version than before
+
+    Reachability is not proof of a completed update: Tasmota acknowledges
+    `Upgrade 1` with HTTP 200 and then downloads and flashes the firmware in the
+    background while it keeps serving requests on the OLD firmware. The new
+    version only runs after the device reboots, which happens seconds to minutes
+    after the command was accepted. Polling the reported version is therefore the
+    only reliable completion signal.
+
+    Args:
+        device_config: Device configuration dictionary
+        previous_version: Firmware version reported before the upgrade command
+        timeout_config: Timeout configuration (intervals and backoff)
+        deadline: Absolute monotonic-ish deadline (time.time() based). Defaults to
+            total_timeout seconds from now.
+
+    Returns:
+        Tuple of (new_firmware_info, timeout_report)
+        - new_firmware_info: Firmware info dict once the version changed, else None
+        - timeout_report: Details about the verification process
+    """
+    ip_address = device_config['ip']
+    start_time = time.time()
+
+    if deadline is None:
+        deadline = start_time + timeout_config.total_timeout
+
+    attempts = 0
+    current_interval = timeout_config.min_check_interval
+    last_seen_version = previous_version
+
+    logger.info(f"{ip_address}: Verifying the device runs a new firmware version "
+                f"(was {previous_version})")
+
+    while time.time() < deadline:
+        attempts += 1
+        firmware_info = get_device_firmware_version(device_config)
+
+        if firmware_info:
+            reported_version = firmware_info.get('version', 'Unknown')
+
+            # "Unknown" means we could not read the version, not that it changed
+            if reported_version not in ('Unknown', None, previous_version):
+                elapsed_time = time.time() - start_time
+                logger.info(f"{ip_address}: Firmware version changed to {reported_version} "
+                            f"after {elapsed_time:.1f}s ({attempts} attempts)")
+
+                return firmware_info, TimeoutReport(
+                    total_timeout=timeout_config.total_timeout,
+                    elapsed_time=elapsed_time,
+                    phase=TimeoutPhase.FIRMWARE_FLASH,
+                    attempts=attempts,
+                    last_check_interval=current_interval,
+                    timed_out=False,
+                    error_type="none",
+                    details={
+                        "success": True,
+                        "previous_version": previous_version,
+                        "new_version": reported_version
+                    }
+                )
+
+            last_seen_version = reported_version
+            logger.debug(f"{ip_address}: Attempt {attempts}: still reporting "
+                         f"{reported_version}, update not applied yet")
+        else:
+            logger.debug(f"{ip_address}: Attempt {attempts}: version unreadable "
+                         f"(device likely rebooting)")
+
+        # Don't sleep past the deadline
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        time.sleep(min(current_interval, remaining))
+
+        current_interval = min(
+            current_interval * timeout_config.backoff_multiplier,
+            timeout_config.max_check_interval
+        )
+
+    elapsed_time = time.time() - start_time
+    logger.warning(f"{ip_address}: Firmware version did not change within {elapsed_time:.1f}s "
+                   f"({attempts} attempts, still reporting {last_seen_version})")
+
+    return None, TimeoutReport(
+        total_timeout=timeout_config.total_timeout,
+        elapsed_time=elapsed_time,
+        phase=TimeoutPhase.FIRMWARE_FLASH,
+        attempts=attempts,
+        last_check_interval=current_interval,
+        timed_out=True,
+        error_type="version_unchanged",
+        details={
+            "message": (
+                f"Device is reachable but still reports version {last_seen_version} "
+                f"after {elapsed_time:.0f} seconds"
+            ),
+            "previous_version": previous_version,
+            "last_seen_version": last_seen_version
+        }
+    )
+
+
 def create_timeout_config(device_config: Dict[str, Any]) -> TimeoutConfig:
     """
     Create timeout configuration from device config with validation
@@ -728,9 +838,10 @@ def update_device_firmware(device_config: Dict[str, Any], check_only: bool = Fal
             "min_check_interval": timeout_config.min_check_interval,
             "max_check_interval": timeout_config.max_check_interval
         },
-        "timeout_report": None
+        "timeout_report": None,
+        "version_verification": None
     }
-    
+
     # Get current firmware version
     firmware_info = get_device_firmware_version(device_config)
     if not firmware_info:
@@ -852,16 +963,34 @@ def update_device_firmware(device_config: Dict[str, Any], check_only: bool = Fal
         result["timeout_report"] = timeout_report.to_dict()
 
         if restart_success:
-            # Device is back online - get new firmware version
-            result["success"] = True
-            result["message"] = "Firmware update completed successfully"
-
+            # The device answers again — but that only proves it is reachable, not
+            # that the new firmware is running. Wait for the reported version to
+            # actually change before claiming success.
             logger.info(f"{device_ip}: Verifying firmware update completion")
-            new_firmware_info = get_device_firmware_version(device_config)
+            new_firmware_info, version_report = verify_firmware_version_changed(
+                device_config,
+                previous_version=firmware_info["version"],
+                timeout_config=timeout_config,
+                deadline=start_time + timeout_config.total_timeout
+            )
+            result["version_verification"] = version_report.to_dict()
+
             if new_firmware_info:
+                result["success"] = True
+                result["message"] = "Firmware update completed successfully"
                 result["current_version"] = new_firmware_info["version"]
+                # Re-evaluate so the UI stops offering an update that already ran
+                result["needs_update"] = compare_versions(
+                    new_firmware_info["version"], latest_release["version"]
+                )
                 logger.info(f"{device_ip}: New firmware version: {new_firmware_info['version']}")
             else:
+                last_seen = version_report.details.get("last_seen_version", "unknown")
+                result["message"] = (
+                    f"Firmware update was initiated, but the device is still running "
+                    f"version {last_seen} after {timeout_config.total_timeout} seconds. "
+                    f"The update may have failed or may still be in progress."
+                )
                 logger.warning(f"{device_ip}: Could not verify new firmware version")
         else:
             # Timeout or other error during restart verification

--- a/app/tasmota/updater.py
+++ b/app/tasmota/updater.py
@@ -188,13 +188,42 @@ def build_device_url(device_config, path="/cm"):
     if not path.startswith('/'):
         path = '/' + path
         
-    # Build the URL
+    # Build the URL. Credentials are deliberately NOT embedded here — they are
+    # passed separately via build_device_auth() so they never become part of a URL
+    # string that could end up in logs, exception messages or response.url, and so
+    # that characters like ':' or '@' in a password cannot corrupt the URL.
     if username and password:
-        # For security, don't log the actual URL with credentials
         logger.debug(f"Building URL for {ip_address} with authentication")
-        return f"http://{username}:{password}@{ip_address}{path}"
-    else:
-        return f"http://{ip_address}{path}"
+
+    return f"http://{ip_address}{path}"
+
+
+def build_device_auth(device_config) -> Optional[Tuple[str, str]]:
+    """
+    Build the HTTP basic auth credentials for a Tasmota device
+
+    Companion to build_device_url(): pass the result as the `auth` argument of the
+    request. This produces the same Authorization header that embedding
+    `user:password@host` in the URL used to produce, without putting the password
+    into the URL itself.
+
+    Args:
+        device_config (dict or str): Device configuration dictionary, or a plain IP
+            address string (which carries no credentials)
+
+    Returns:
+        Tuple of (username, password), or None if the device needs no authentication
+    """
+    if not isinstance(device_config, dict):
+        return None
+
+    username = device_config.get('username')
+    password = device_config.get('password')
+
+    if username and password:
+        return (username, password)
+
+    return None
 
 
 def get_dns_name(device_config):
@@ -292,7 +321,12 @@ def get_device_firmware_version(device_config: Dict[str, Any]) -> Optional[Dict[
     
     try:
         logger.debug(f"{ip_address}: Requesting firmware version information")
-        response = requests.get(base_url, params=params, timeout=timeout)
+        response = requests.get(
+            base_url,
+            params=params,
+            timeout=timeout,
+            auth=build_device_auth(device_config)
+        )
         
         if response.status_code == 200:
             try:
@@ -385,7 +419,8 @@ def verify_device_restart_with_backoff(
             response = requests.get(
                 base_url,
                 timeout=timeout_config.request_timeout,
-                params={"cmnd": "Status"}  # Simple status check
+                params={"cmnd": "Status"},  # Simple status check
+                auth=build_device_auth(device_config)
             )
 
             if response.status_code == 200:
@@ -939,7 +974,8 @@ def update_device_firmware(device_config: Dict[str, Any], check_only: bool = Fal
             response = requests.get(
                 base_url,
                 params=params,
-                timeout=timeout_config.request_timeout
+                timeout=timeout_config.request_timeout,
+                auth=build_device_auth(device_config)
             )
         except requests.exceptions.Timeout:
             elapsed_time = time.time() - start_time

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -148,11 +148,14 @@
                                                     </div>
                                                 </div>
                                                 
-                                                <!-- Update completed indicator -->
+                                                <!-- Update completed indicator (reflects the verified outcome,
+                                                     so it can never contradict the tag above) -->
                                                 <div x-show="device.update_completed" class="mt-3">
-                                                    <p class="has-text-success">
-                                                        <span class="icon"><i class="fas fa-check-circle"></i></span>
-                                                        <span class="ml-2">Update completed successfully</span>
+                                                    <p :class="device.update_verified === false ? 'has-text-warning-dark' : 'has-text-success'">
+                                                        <span class="icon">
+                                                            <i class="fas" :class="device.update_verified === false ? 'fa-exclamation-triangle' : 'fa-check-circle'"></i>
+                                                        </span>
+                                                        <span class="ml-2" x-text="device.update_result_message || 'Update completed successfully'"></span>
                                                     </p>
                                                 </div>
                                             </div>

--- a/tests/e2e/test_update_refreshes_card.py
+++ b/tests/e2e/test_update_refreshes_card.py
@@ -27,3 +27,9 @@ def test_single_update_refetches_device_status(page: Page, app_server: str):
         page.get_by_role("button", name="Update", exact=True).click()  # confirm modal
 
     expect(page.get_by_text("Update completed successfully").first).to_be_visible(timeout=10000)
+
+    # The status refetch has settled by now. A fake device keeps reporting its
+    # original version, so the "still offers an update" warning must stay away —
+    # it is reserved for real devices that came back on the old firmware.
+    page.wait_for_timeout(1000)
+    expect(page.get_by_text("still offers an update")).to_have_count(0)

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -1,0 +1,84 @@
+"""Tests for device authentication handling.
+
+Credentials used to be embedded in the request URL (`http://user:pass@ip/cm`).
+They are now passed via the request's `auth` argument instead, which produces the
+same Authorization header while keeping the password out of the URL string — so it
+cannot leak through logs, exception messages or `response.url`, and characters like
+`:` or `@` in a password can no longer corrupt the URL.
+"""
+
+import requests
+
+from app.tasmota.updater import build_device_auth, build_device_url
+
+DEVICE = {"ip": "192.168.8.191", "username": "admin", "password": "s3cr3t"}
+
+
+class TestBuildDeviceUrl:
+    def test_url_carries_no_credentials(self):
+        url = build_device_url(DEVICE)
+
+        assert url == "http://192.168.8.191/cm"
+        assert "s3cr3t" not in url
+        assert "admin" not in url
+
+    def test_accepts_a_plain_ip_string(self):
+        assert build_device_url("192.168.8.191") == "http://192.168.8.191/cm"
+
+    def test_honours_a_custom_path(self):
+        assert build_device_url(DEVICE, path="status") == "http://192.168.8.191/status"
+
+    def test_rejects_an_invalid_address(self):
+        assert build_device_url({"ip": "not-an-ip"}) is None
+
+
+class TestBuildDeviceAuth:
+    def test_returns_the_credential_pair(self):
+        assert build_device_auth(DEVICE) == ("admin", "s3cr3t")
+
+    def test_returns_none_without_credentials(self):
+        assert build_device_auth({"ip": "192.168.8.191"}) is None
+
+    def test_returns_none_when_only_one_half_is_set(self):
+        assert build_device_auth({"ip": "192.168.8.191", "username": "admin"}) is None
+        assert build_device_auth({"ip": "192.168.8.191", "password": "s3cr3t"}) is None
+
+    def test_returns_none_for_a_plain_ip_string(self):
+        assert build_device_auth("192.168.8.191") is None
+
+
+class TestWireEquivalence:
+    """The request on the wire must be unchanged by moving credentials out of the URL."""
+
+    def _prepared_authorization(self, url, auth):
+        return requests.Request("GET", url, auth=auth).prepare().headers.get("Authorization")
+
+    def test_auth_argument_matches_the_previous_userinfo_url(self):
+        legacy = self._prepared_authorization("http://admin:s3cr3t@192.168.8.191/cm", None)
+        current = self._prepared_authorization(build_device_url(DEVICE), build_device_auth(DEVICE))
+
+        assert current == legacy
+        assert current.startswith("Basic ")
+
+    def test_passwords_with_url_metacharacters_now_survive(self):
+        """A password containing ':' or '@' used to corrupt the embedded URL."""
+        device = {"ip": "192.168.8.191", "username": "admin", "password": "p@ss:word"}
+
+        prepared = requests.Request(
+            "GET", build_device_url(device), auth=build_device_auth(device)
+        ).prepare()
+
+        assert prepared.url.startswith("http://192.168.8.191/cm")
+        assert "p@ss:word" not in prepared.url
+        # Decodes back to the exact credentials the device expects
+        import base64
+        token = prepared.headers["Authorization"].split(" ", 1)[1]
+        assert base64.b64decode(token).decode() == "admin:p@ss:word"
+
+    def test_no_authorization_header_without_credentials(self):
+        device = {"ip": "192.168.8.191"}
+        prepared = requests.Request(
+            "GET", build_device_url(device), auth=build_device_auth(device)
+        ).prepare()
+
+        assert "Authorization" not in prepared.headers

--- a/tests/test_firmware_version_verification.py
+++ b/tests/test_firmware_version_verification.py
@@ -17,6 +17,7 @@ from app.tasmota.updater import (
     TimeoutConfig,
     TimeoutReport,
     TimeoutPhase,
+    log_safe_address,
     update_device_firmware,
     verify_firmware_version_changed,
 )
@@ -64,6 +65,25 @@ def restart_verified_report(total_timeout=240):
 @pytest.fixture
 def clock():
     return FakeClock()
+
+
+class TestLogSafeAddress:
+    """The address used in log messages is normalized, never taken verbatim."""
+
+    def test_normalizes_a_valid_address(self):
+        assert log_safe_address(" 192.168.8.191 ") == "192.168.8.191"
+
+    def test_normalizes_ipv6(self):
+        assert log_safe_address("FE80::1") == "fe80::1"
+
+    @pytest.mark.parametrize("value", [
+        "192.168.8.191\nfake log line",  # would forge an extra log record
+        "not-an-ip",
+        "",
+        None,
+    ])
+    def test_replaces_anything_that_is_not_an_ip(self, value):
+        assert log_safe_address(value) == "<invalid-address>"
 
 
 class TestVerifyFirmwareVersionChanged:

--- a/tests/test_firmware_version_verification.py
+++ b/tests/test_firmware_version_verification.py
@@ -1,0 +1,254 @@
+"""Tests for post-OTA firmware version verification.
+
+Tasmota acknowledges `Upgrade 1` with HTTP 200 and then downloads and flashes
+the new firmware *in the background* while still serving requests on the OLD
+firmware. Reachability is therefore not proof of a completed update: the device
+only runs the new version after it reboots, which happens seconds to minutes
+after the command was accepted.
+
+These tests pin down that `update_device_firmware()` must not report success
+until the device actually reports a different firmware version.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from app.tasmota.updater import (
+    TimeoutConfig,
+    TimeoutReport,
+    TimeoutPhase,
+    update_device_firmware,
+    verify_firmware_version_changed,
+)
+
+OLD_VERSION = "15.2.0(release-tasmota-4M)"
+NEW_VERSION = "15.5.0(release-tasmota-4M)"
+
+
+class FakeClock:
+    """Deterministic clock so backoff loops don't burn real wall-clock time."""
+
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def time(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+def firmware(version):
+    return {
+        "version": version,
+        "core_version": "2.7.8",
+        "sdk_version": "2.2.2-dev(38a443e)",
+        "is_minimal": False,
+    }
+
+
+def restart_verified_report(total_timeout=240):
+    """Report as produced when the device answers HTTP 200 again."""
+    return TimeoutReport(
+        total_timeout=total_timeout,
+        elapsed_time=10.0,
+        phase=TimeoutPhase.RESTART_VERIFICATION,
+        attempts=1,
+        last_check_interval=1.0,
+        timed_out=False,
+        error_type="none",
+        details={"success": True, "final_status_code": 200},
+    )
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+class TestVerifyFirmwareVersionChanged:
+    """Unit tests for the version-based verification helper."""
+
+    def test_returns_new_firmware_once_version_changes(self, clock):
+        config = TimeoutConfig(total_timeout=240)
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            # Still flashing on the old firmware, then rebooted onto the new one
+            mock_version.side_effect = [
+                firmware(OLD_VERSION),
+                firmware(OLD_VERSION),
+                firmware(NEW_VERSION),
+            ]
+
+            info, report = verify_firmware_version_changed(
+                {"ip": "192.168.8.191"}, OLD_VERSION, config
+            )
+
+        assert info["version"] == NEW_VERSION
+        assert report.timed_out is False
+        assert report.attempts == 3
+
+    def test_tolerates_device_being_offline_while_rebooting(self, clock):
+        config = TimeoutConfig(total_timeout=240)
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            # Unreachable mid-reboot (None), then back with the new firmware
+            mock_version.side_effect = [None, None, firmware(NEW_VERSION)]
+
+            info, report = verify_firmware_version_changed(
+                {"ip": "192.168.8.191"}, OLD_VERSION, config
+            )
+
+        assert info["version"] == NEW_VERSION
+        assert report.timed_out is False
+
+    def test_ignores_unknown_version_readings(self, clock):
+        config = TimeoutConfig(total_timeout=240)
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            mock_version.side_effect = [
+                firmware("Unknown"),
+                firmware(NEW_VERSION),
+            ]
+
+            info, report = verify_firmware_version_changed(
+                {"ip": "192.168.8.191"}, OLD_VERSION, config
+            )
+
+        assert info["version"] == NEW_VERSION
+
+    def test_times_out_when_version_never_changes(self, clock):
+        config = TimeoutConfig(total_timeout=120)
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            mock_version.return_value = firmware(OLD_VERSION)
+
+            info, report = verify_firmware_version_changed(
+                {"ip": "192.168.8.191"}, OLD_VERSION, config
+            )
+
+        assert info is None
+        assert report.timed_out is True
+        assert report.error_type == "version_unchanged"
+        assert report.phase == TimeoutPhase.FIRMWARE_FLASH
+
+    def test_respects_an_externally_supplied_deadline(self, clock):
+        config = TimeoutConfig(total_timeout=600)
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            mock_version.return_value = firmware(OLD_VERSION)
+
+            info, report = verify_firmware_version_changed(
+                {"ip": "192.168.8.191"},
+                OLD_VERSION,
+                config,
+                deadline=clock.now + 30,
+            )
+
+        assert info is None
+        assert report.timed_out is True
+        # The deadline, not total_timeout, bounds the loop
+        assert report.elapsed_time <= 30 + config.max_check_interval
+
+
+class TestUpdateDeviceFirmwareVersionVerification:
+    """update_device_firmware() must verify the running firmware, not just reachability."""
+
+    def _patched_update(self, clock, version_readings, compare_results=None):
+        """Run update_device_firmware with the network boundary mocked out."""
+        patches = {
+            "get_device_firmware_version": None,
+            "fetch_latest_tasmota_release": None,
+            "compare_versions": None,
+            "is_fake_device": None,
+            "build_device_url": None,
+        }
+
+        with patch("app.tasmota.updater.time") as mock_time, \
+             patch("app.tasmota.updater.get_device_firmware_version") as mock_version, \
+             patch("app.tasmota.updater.fetch_latest_tasmota_release") as mock_latest, \
+             patch("app.tasmota.updater.compare_versions") as mock_compare, \
+             patch("app.tasmota.updater.is_fake_device") as mock_fake, \
+             patch("app.tasmota.updater.build_device_url") as mock_url, \
+             patch("app.tasmota.updater.requests.get") as mock_get, \
+             patch("app.tasmota.updater.verify_device_restart_with_backoff") as mock_restart:
+            mock_time.time.side_effect = clock.time
+            mock_time.sleep.side_effect = clock.sleep
+            mock_version.side_effect = version_readings
+            mock_latest.return_value = {"version": "15.5.0"}
+            if compare_results is None:
+                mock_compare.return_value = True
+            else:
+                mock_compare.side_effect = compare_results
+            mock_fake.return_value = False
+            mock_url.return_value = "http://192.168.8.191/cm"
+
+            mock_get.return_value.status_code = 200
+            # The device answers again right away — it never actually rebooted yet
+            mock_restart.return_value = (True, restart_verified_report())
+
+            return update_device_firmware(
+                {"ip": "192.168.8.191", "timeout": 240}, check_only=False
+            )
+
+    def test_does_not_claim_success_while_old_firmware_still_running(self, clock):
+        """Regression: reachable + old version was reported as a successful update."""
+        result = self._patched_update(
+            clock,
+            # Pre-update read, then the device keeps reporting the old version
+            version_readings=[firmware(OLD_VERSION)] + [firmware(OLD_VERSION)] * 60,
+        )
+
+        assert result["success"] is False
+        assert result["current_version"] == OLD_VERSION
+        # The card must keep offering the update instead of showing "Up to Date"
+        assert result["needs_update"] is True
+        assert "still running" in result["message"].lower()
+
+    def test_reports_success_with_the_new_version_after_the_flash_window(self, clock):
+        result = self._patched_update(
+            clock,
+            version_readings=[
+                firmware(OLD_VERSION),  # pre-update check
+                firmware(OLD_VERSION),  # still flashing, old firmware serving
+                firmware(OLD_VERSION),
+                firmware(NEW_VERSION),  # rebooted onto the new firmware
+            ],
+            # needs_update before the update, then re-evaluated afterwards
+            compare_results=[True, False],
+        )
+
+        assert result["success"] is True
+        assert result["current_version"] == NEW_VERSION
+        assert result["needs_update"] is False
+        assert "completed successfully" in result["message"].lower()
+
+    def test_exposes_the_version_verification_report(self, clock):
+        result = self._patched_update(
+            clock,
+            version_readings=[
+                firmware(OLD_VERSION),
+                firmware(NEW_VERSION),
+            ],
+            compare_results=[True, False],
+        )
+
+        assert result["version_verification"]["timed_out"] is False
+        assert result["version_verification"]["phase"] == TimeoutPhase.FIRMWARE_FLASH.value
+        # The reachability report stays intact alongside it
+        assert result["timeout_report"]["phase"] == TimeoutPhase.RESTART_VERIFICATION.value


### PR DESCRIPTION
Behebt #87 — nach einem Update stand die alte Versionsnummer plus `Update Available` neben der Erfolgsmeldung.

## Ursache

Tasmota quittiert `Upgrade 1` **sofort mit HTTP 200** und flasht dann im Hintergrund, während es weiter auf der **alten** Firmware läuft und HTTP beantwortet. `verify_device_restart_with_backoff()` wertete den ersten HTTP-200 nach dem `initial_wait` (max. 10s) als „Restart fertig" — also noch im Flash-Fenster. Folge: `success = True`, alte Version im Ergebnis, `needs_update` unverändert `true`.

Die Verifikation setzte *erreichbar* mit *aktualisiert* gleich. Das ist eine Ebene tiefer als #84 (dort war der Refetch das Problem, hier liefert der Refetch korrekt — nur eben noch die alte Version).

## Änderungen

**1. Versions-Verifikation (Ursachenfix)**
- `verify_firmware_version_changed()` (neu): pollt die gemeldete Version mit Backoff, bis sie sich tatsächlich von der Vor-Update-Version unterscheidet. `None`/`Unknown` gelten als „noch nicht fertig". Teilt sich das `total_timeout`-Budget über eine gemeinsame Deadline.
- `update_device_firmware()`: meldet `success` erst nach bestätigter Versionsänderung, rechnet `needs_update` danach neu und liefert im Timeout-Fall eine ehrliche Fehlermeldung statt falschem Erfolg.
- Neues Antwortfeld `version_verification` (Swagger dokumentiert); `timeout_report` bleibt unverändert, damit die bestehende API-Zusage hält.
- Batch-Updates erben den Fix über `update_device_firmware()`.

**2. Frontend**
- Die grüne Meldung war in `index.html` hart verdrahtet und erschien immer bei `update_completed`. Jetzt zustandsgetrieben — Erfolgsmeldung und `Update Available` können sich nicht mehr widersprechen. Greift nur noch als Defense in Depth; Fake-Devices ausgenommen, da ihre Simulation die Version nie ändert.
- Client-Timeout für `POST /api/update`: `60s` → `(device.timeout || 240) + 30`. Ohne das bricht die UI ab, bevor die Verifikation durch ist — das Backend antwortet jetzt erst nach dem echten Reboot.

**3. Credentials raus aus der URL**
`build_device_url()` baute `http://user:password@ip`. Neu: `build_device_auth()` als Gegenstück, Credentials gehen über den `auth`-Parameter an alle drei Geräte-Requests.
- `requests` erzeugt aus Userinfo ohnehin denselben Basic-Auth-Header — der Request ist **auf dem Draht identisch**, festgenagelt durch einen Wire-Äquivalenz-Test.
- Das Passwort steckt in keinem String mehr, der in Logs, Exception-Texte oder `response.url` geraten kann. `sanitize_log_data()` ist damit zweite Verteidigungslinie statt einzige.
- Behebt einen latenten Bug: ein Passwort mit `:` oder `@` zerlegte die eingebettete URL. Über `auth` wird es korrekt kodiert.
- Nebeneffekt: löst die CodeQL-Findings `py/clear-text-logging-sensitive-data` an der Wurzel. Das Passwort floss in die Request-URL, CodeQL vererbt diesen Taint auf den Response-Body — dadurch galt **jede** aus einem Gerät gelesene Versionsnummer als Passwort, und jede Log-Zeile mit einer Version wurde als Klartext-Logging gemeldet. Vorher waren 3 solche Alerts im Repo als False Positive verworfen; die Quelle ist nun weg.

## Tests

- `tests/test_firmware_version_verification.py` (neu, 14 Tests): Versionswechsel, Offline-Phase im Reboot, `Unknown`-Readings, Timeout, externes Deadline-Budget, die Regression „erreichbar + alte Version ≠ Erfolg" sowie `log_safe_address()`. Deterministische Fake-Clock, keine echten Wartezeiten.
- `tests/test_device_auth.py` (neu, 11 Tests): URL ohne Credentials, `auth`-Paar, Wire-Äquivalenz des Authorization-Headers, Passwörter mit URL-Metazeichen, kein Header ohne Credentials.
- `tests/e2e/test_update_refreshes_card.py`: prüft zusätzlich, dass der Warnhinweis auf Fake-Devices ausbleibt. Per Gegenprobe verifiziert, dass die Assertion ohne den Fix rot wird.
- Grüner Kern: 69 passed, 1 skipped. E2E: 4 passed.

## Was ich nicht verifizieren konnte

Gegen echte Hardware ist nichts getestet — das Flash-Fenster lässt sich mit Fake-Devices nicht reproduzieren, und der Auth-Weg ist nur über die Wire-Äquivalenz abgesichert, nicht gegen ein Gerät mit gesetztem Passwort. Bitte an 192.168.8.191 gegentesten: die Karte sollte nach dem Update direkt die neue Version plus `Up to Date` zeigen, ohne manuelles „Check". Ohne Passwort in der `devices.yaml` ändert sich am Auth-Verhalten ohnehin nichts.
