### PR TITLE
docs: fix README defects, require a README check, unflake the e2e job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,4 +85,12 @@ jobs:
       - name: Run end-to-end tests (fake devices)
         # -o addopts="" drops the unit-suite coverage flags (pointless here: the
         # app runs in a subprocess, so in-process coverage measures nothing).
+        #
+        # GITHUB_TOKEN is required, not optional: the app looks up the latest
+        # Tasmota release from api.github.com on every run (the response cache is
+        # gitignored, so CI always starts cold). Unauthenticated that is 60 req/h
+        # per IP, shared across runners — when it 403s, no device "needs" an update
+        # and the update-flow tests fail with a misleading timeout.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .venv/bin/python -m pytest tests/e2e -m e2e -o addopts="" --timeout=120

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ When making changes:
 3. Verify API endpoints via Swagger UI
 4. Use conventional commit messages (release-please derives the version)
 5. Update documentation in `docs/` directory as needed
+6. **Check `README.md` before opening any PR** — including Dependabot/Renovate PRs, where it should be reviewed together with the maintainer. It drifts unnoticed because nothing in a normal diff touches it: a dependency bump can silently invalidate a badge or a minimum version, and broken markdown never fails a test. Verify code fences are balanced (`grep -c '^```' README.md` must be even), plus badges, the clone URL, ports, commands, and that deprecated paths aren't presented as current. Careful when "correcting" names: the container images really are `dodjango/tasmota-updater` (both registries, see `publish-container.yml`) while the *git* repo is `dodjango/tasmota-auto-updater`.
 
 ## CI, Testing & Gotchas
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Keep your Tasmota devices up to date with a single command or click
 
 [![Semantic Versioning](https://img.shields.io/badge/semver-2.0.0-brightgreen)](https://semver.org)
-[![Python 3.6+](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Tasmota Remote Updater is a tool that automatically updates multiple Tasmota devices to the latest firmware over your network. No more manual updates or complex scripts - just point it at your devices and let it handle the rest.
@@ -24,8 +24,8 @@ Tasmota Remote Updater is a tool that automatically updates multiple Tasmota dev
 
 ```bash
 # Clone the repository
-git clone https://github.com/dodjango/tasmota-updater.git
-cd tasmota-updater
+git clone https://github.com/dodjango/tasmota-auto-updater.git
+cd tasmota-auto-updater
 
 # Create a virtual environment and install dependencies
 python -m venv venv
@@ -44,8 +44,8 @@ Then visit http://localhost:5001 in your browser.
 
 ```bash
 # Clone the repository and run with Docker or Podman
-git clone https://github.com/dodjango/tasmota-updater.git
-cd tasmota-updater
+git clone https://github.com/dodjango/tasmota-auto-updater.git
+cd tasmota-auto-updater
 
 # Using Docker
 docker compose up -d
@@ -67,6 +67,15 @@ docker run -d -p 5001:5001 \
   -v $(pwd)/devices.yaml:/app/devices.yaml \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater dodjango/tasmota-updater:latest
+
+# OR run with Podman
+podman run -d -p 5001:5001 \
+  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/logs:/app/logs \
+  --name tasmota-updater dodjango/tasmota-updater:latest
+```
+
+Then visit http://localhost:5001 in your browser.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## 1. README: nicht geschlossener Code-Fence

Der `bash`-Fence unter „Option 2: Pull from container registry" wurde **nie geschlossen**. Dadurch rendert alles ab den `docker pull`-Zeilen bis zum Dateiende als ein einziger Code-Block — Documentation, Contributing, License, Acknowledgments und Versioning erscheinen als Shell-Code.

Gegenprobe: `grep -c '^```' README.md` lieferte **5** (ungerade). Jetzt 6, alle Fences paarweise.

Dabei zwei weitere veraltete Angaben korrigiert:
- **Clone-URL** zeigte auf `github.com/dodjango/tasmota-updater` — existiert nicht, das Repo heißt `dodjango/tasmota-auto-updater` (2 Stellen). Die *Container-Images* heißen tatsächlich `dodjango/tasmota-updater` (beide Registries, siehe `publish-container.yml`), die bleiben unverändert.
- **Python-Badge:** `3.6+` → `3.10+`, passend zu `requires-python = ">=3.10"` und der CI-Matrix 3.10–3.12.
- Podman-Variante in Option 2 ergänzt, damit sie beide Runtimes abdeckt wie Option 1 schon.

## 2. CLAUDE.md: README-Check als Workflow-Schritt

Die README driftet unbemerkt, weil sie in keinem normalen Diff auftaucht. Der Check ist jetzt expliziter Schritt der Development-Workflow-Liste — ausdrücklich auch für Dependabot-/Renovate-PRs, wo ein Bump ein Badge oder eine Mindestversion still ungültig machen kann.

## 3. CI: `GITHUB_TOKEN` für den e2e-Job

Der e2e-Lauf dieses PRs schlug fehl, obwohl hier nur Markdown geändert wird. Ursache:

Die App löst bei jedem Start die neueste Tasmota-Version über `api.github.com` auf, und der Response-Cache (`app/tasmota/cache/`) ist gitignored — CI startet also immer kalt und macht einen Live-Call. Ohne Token gilt das unauthentifizierte Limit von **60 req/h pro IP**, geteilt über die Actions-Runner. Bei einem 403 liefert `fetch_latest_tasmota_release()` `None`, kein Gerät „braucht" ein Update, und alle Karten rendern `Up to Date` — der Update-Flow-Test scheitert dann mit einem irreführenden Timeout beim Warten auf `Update Available`, ohne dass im Job-Log die Ursache steht.

Belege: alle vier Fake-Devices kippten gleichzeitig auf `Up to Date` (Versionen 11.0.0–12.0.2 gegen echte 15.x), und derselbe Code war bei #88 kurz vorher grün.

Der Token kommt via `env:` aus `secrets.GITHUB_TOKEN`; die Job-Permissions bleiben bei `contents: read`.

**Nicht in diesem PR:** dass ein *fehlgeschlagener* Lookup überhaupt als `Up to Date` angezeigt wird, ist ein eigener Anzeige-Bug — als #91 erfasst, gleiche Klasse wie #87.
