### PR TITLE
fix(ui): don't show an unknown firmware version as "Up to Date"

### DIFF
--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -32,7 +32,19 @@ function tasmotaApp() {
             const host = device.dns_name || device.ip;
             return `http://${host}`;
         },
-        
+
+        // Whether the device's firmware was actually compared against a known
+        // latest release. When the release lookup (or the device version read)
+        // fails, the API returns needs_update: false with latest_version
+        // "Unknown" — that must not be shown as "Up to Date", because nothing
+        // was compared. Deliberately keyed on latest_version rather than
+        // success: a failed *update* still carries a known latest version.
+        isVersionComparisonKnown(device) {
+            const status = device.update_status;
+            return !!(status && status.latest_version && status.latest_version !== 'Unknown');
+        },
+
+
         // Computed properties
         get hasUpdatableDevices() {
             return this.devices.some(device => 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -134,8 +134,13 @@
                                                 
                                                 <div class="tags mt-2">
                                                     <span x-show="device.status.is_minimal" class="tag is-warning">Minimal</span>
-                                                    <span x-show="device.update_status && device.update_status.needs_update" class="tag is-danger">Update Available</span>
-                                                    <span x-show="device.update_status && !device.update_status.needs_update" class="tag is-success">Up to Date</span>
+                                                    <span x-show="isVersionComparisonKnown(device) && device.update_status.needs_update" class="tag is-danger">Update Available</span>
+                                                    <span x-show="isVersionComparisonKnown(device) && !device.update_status.needs_update" class="tag is-success">Up to Date</span>
+                                                    <!-- No comparison happened (release lookup or version read failed) —
+                                                         showing "Up to Date" here would report a failure as healthy. -->
+                                                    <span x-show="device.update_status && !isVersionComparisonKnown(device)"
+                                                          class="tag is-warning"
+                                                          :title="device.update_status && device.update_status.message ? device.update_status.message : 'Could not determine the latest firmware version'">Version unknown</span>
                                                 </div>
                                                 
                                                 <!-- Update status indicator -->

--- a/tests/e2e/test_unknown_version_state.py
+++ b/tests/e2e/test_unknown_version_state.py
@@ -1,0 +1,75 @@
+"""Regression E2E: when the latest firmware version cannot be determined, the
+card must not claim "Up to Date".
+
+The API returns `needs_update: false` both for an up-to-date device and for a
+failed release lookup (e.g. a GitHub API rate limit), so keying the green tag on
+`needs_update` alone reported a failure as a healthy state. The check response is
+stubbed here because the real failure depends on an external service.
+"""
+import json
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+
+def _stub_check(page: Page, payload_extra):
+    """Answer the UI's check call (POST /api/update with check_only) with a stub."""
+
+    def handler(route):
+        request = route.request
+        if request.method != "POST":
+            return route.fallback()
+        body = request.post_data_json or {}
+        if not body.get("check_only"):
+            return route.fallback()
+
+        payload = {
+            "ip": body.get("ip"),
+            "current_version": "12.0.2",
+            "needs_update": False,
+            **payload_extra,
+        }
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    page.route("**/api/update", handler)
+
+
+def test_failed_release_lookup_is_not_shown_as_up_to_date(page: Page, app_server: str):
+    _stub_check(page, {
+        "success": False,
+        "message": "Failed to get latest release information",
+        "latest_version": "Unknown",
+    })
+
+    page.goto(app_server + "/")
+    card = page.locator(".card").first
+    expect(card).to_be_visible()
+
+    # The honest state is surfaced ...
+    expect(card.get_by_text("Version unknown")).to_be_visible(timeout=30000)
+    # ... and the misleading ones stay hidden. (x-show keeps the elements in the
+    # DOM and only toggles display, so assert visibility, not element count.)
+    expect(card.get_by_text("Up to Date")).to_be_hidden()
+    expect(card.get_by_text("Update Available")).to_be_hidden()
+
+
+def test_a_real_comparison_still_shows_up_to_date(page: Page, app_server: str):
+    """Contrast case: a concrete latest_version keeps the green tag working."""
+    _stub_check(page, {
+        "success": True,
+        "message": "Device is already running the latest version",
+        "latest_version": "12.0.2",
+    })
+
+    page.goto(app_server + "/")
+    card = page.locator(".card").first
+    expect(card).to_be_visible()
+
+    expect(card.get_by_text("Up to Date")).to_be_visible(timeout=30000)
+    expect(card.get_by_text("Version unknown")).to_be_hidden()

--- a/tests/test_unknown_version_state.py
+++ b/tests/test_unknown_version_state.py
@@ -1,0 +1,85 @@
+"""Tests for the "latest version unknown" case.
+
+When the latest release cannot be determined, the API returns
+`needs_update: false` — the same value it returns for an up-to-date device. The
+UI therefore must not key "Up to Date" on `needs_update` alone; it distinguishes
+the cases via `latest_version`. These tests pin that contract down so the two
+situations stay tellable apart.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from app.tasmota.updater import update_device_firmware
+
+DEVICE = {"ip": "192.168.8.191", "timeout": 60}
+
+
+def firmware(version="15.2.0"):
+    return {
+        "version": version,
+        "core_version": "2.7.8",
+        "sdk_version": "2.2.2-dev",
+        "is_minimal": False,
+    }
+
+
+class TestFailedReleaseLookup:
+    """A failed GitHub release lookup must stay distinguishable from "up to date"."""
+
+    def _check(self):
+        with patch("app.tasmota.updater.get_device_firmware_version") as mock_version, \
+             patch("app.tasmota.updater.fetch_latest_tasmota_release") as mock_latest:
+            mock_version.return_value = firmware()
+            mock_latest.return_value = None  # e.g. GitHub API rate limit
+            return update_device_firmware(DEVICE, check_only=True)
+
+    def test_reports_failure_rather_than_success(self):
+        result = self._check()
+
+        assert result["success"] is False
+        assert "latest release" in result["message"].lower()
+
+    def test_latest_version_stays_unknown(self):
+        """This is the field the UI uses to tell "unknown" from "up to date"."""
+        result = self._check()
+
+        assert result["latest_version"] == "Unknown"
+        assert result["needs_update"] is False
+
+    def test_current_version_is_still_reported(self):
+        result = self._check()
+
+        assert result["current_version"] == "15.2.0"
+
+
+class TestFailedDeviceVersionRead:
+    """An unreachable device must not look up to date either."""
+
+    def test_latest_version_stays_unknown(self):
+        with patch("app.tasmota.updater.get_device_firmware_version") as mock_version:
+            mock_version.return_value = None
+            result = update_device_firmware(DEVICE, check_only=True)
+
+        assert result["success"] is False
+        assert result["latest_version"] == "Unknown"
+        assert result["needs_update"] is False
+
+
+class TestSuccessfulComparison:
+    """Contrast: a real comparison always carries a concrete latest_version."""
+
+    @pytest.mark.parametrize("needs_update", [True, False])
+    def test_latest_version_is_concrete(self, needs_update):
+        with patch("app.tasmota.updater.get_device_firmware_version") as mock_version, \
+             patch("app.tasmota.updater.fetch_latest_tasmota_release") as mock_latest, \
+             patch("app.tasmota.updater.compare_versions") as mock_compare:
+            mock_version.return_value = firmware()
+            mock_latest.return_value = {"version": "15.5.0"}
+            mock_compare.return_value = needs_update
+            result = update_device_firmware(DEVICE, check_only=True)
+
+        assert result["success"] is True
+        assert result["latest_version"] == "15.5.0"
+        assert result["latest_version"] != "Unknown"
+        assert result["needs_update"] is needs_update


### PR DESCRIPTION
Behebt #91.

## Problem

`needs_update: false` bedeutet zwei völlig verschiedene Dinge:

| Situation | `success` | `latest_version` | `needs_update` |
|---|---|---|---|
| Gerät ist aktuell | `true` | `15.5.0` | `false` |
| Release-Lookup fehlgeschlagen (z. B. Rate-Limit) | `false` | `Unknown` | `false` |
| Geräte-Version nicht lesbar | `false` | `Unknown` | `false` |

Die Karte hing den grünen `Up to Date`-Tag allein an `needs_update` — ein Fehler wurde also als gesunder Zustand dargestellt. Aufgefallen beim Debuggen des e2e-Fehlschlags in #90: alle vier Fake-Devices standen auf `Up to Date` (Versionen 11.0.0–12.0.2 gegen echte 15.x), und das einzige Symptom war ein Test-Timeout beim Warten auf `Update Available`. Die Rate-Limit-Ursache ist in #90 behoben; das hier ist der Anzeige-Fehler darunter.

Gleiche Klasse wie #87, wo *erreichbar* als *aktualisiert* galt.

## Lösung

Dritter Zustand `Version unknown` (Warn-Tag, mit der API-Meldung als Tooltip), wenn kein Vergleich stattgefunden hat. `Up to Date` **und** `Update Available` setzen jetzt beide eine bekannte `latest_version` voraus.

Der Check hängt bewusst an `latest_version` und **nicht** an `success`: nach einem fehlgeschlagenen *Update* (siehe #87/#88) ist `success: false`, obwohl der Vergleich stattfand — dort muss weiterhin `Update Available` stehen.

Die Update-Buttons bleiben unberührt: sie hängen an `needs_update`, sind im Unknown-Fall also weiterhin deaktiviert.

## Tests

- `tests/test_unknown_version_state.py` (neu, 6 Tests): nagelt den Backend-Vertrag fest, auf den die UI baut — fehlgeschlagener Release-Lookup und nicht lesbare Geräte-Version liefern beide `latest_version: "Unknown"`, ein echter Vergleich immer eine konkrete Version (beide Richtungen von `needs_update`).
- `tests/e2e/test_unknown_version_state.py` (neu, 2 Tests): stubbt die Check-Antwort per `page.route` (der echte Fehlerfall hängt an einem externen Dienst) und prüft beide Richtungen — Unknown zeigt kein `Up to Date`, ein echter Vergleich zeigt es weiterhin.
- Gegenprobe gefahren: mit dem alten Template wird der e2e-Test rot („Aria snapshot: - text: Up to Date").
- Grüner Kern: 75 passed, 1 skipped. E2E: 6 passed.

Hinweis: `x-show` lässt die Elemente im DOM und schaltet nur `display`, daher prüfen die Tests Sichtbarkeit statt Element-Anzahl.

## Offen aus #91

Den Release-Lookup in der e2e-Suite generell zu stubben (statt nur in diesen zwei Tests) bleibt offen — damit hängt die Suite weiterhin daran, dass die echte Tasmota-Version neuer ist als die der Fake-Devices. Sinnvoll als eigener Schritt zu #76.
