### PR TITLE
docs: stop documenting the deprecated CLI as working

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Tasmota Remote Updater is a Python Flask application that allows remote updating of multiple Tasmota devices via CLI, web interface, and REST API. The application follows a modular architecture with separate components for core functionality, web interface, and API endpoints.
+Tasmota Remote Updater is a Python Flask application that allows remote updating of multiple Tasmota devices via a web interface and a REST API. The application follows a modular architecture with separate components for core functionality, web interface, and API endpoints. (A CLI existed but is deprecated — see below.)
 
 ## Core Architecture
 
@@ -23,7 +23,7 @@ Tasmota Remote Updater is a Python Flask application that allows remote updating
 - **Configuration**: YAML-based device configuration with support for authentication and fake devices for testing
 
 ### Key Design Patterns
-- **Modular separation**: CLI logic extracted from web application into reusable modules
+- **Modular separation**: the update logic lives in `app/tasmota` and is shared by the web UI and the API (no duplicated copies — that duplication is exactly what killed the CLI)
 - **Security-first**: Credential sanitization in logs, no sensitive data exposure
 - **Fake device support**: Development mode with simulated devices for testing
 - **Environment-based configuration**: `.env` files for different deployment scenarios
@@ -37,16 +37,13 @@ python server.py
 
 # With fake devices for development
 ENV_FILE=.env.dev python server.py
-
-# CLI interface
-python tasmota_updater.py -f devices.yaml
-
-# CLI dry run mode
-python tasmota_updater.py --dry-run
-
-# Check firmware versions only
-python tasmota_updater.py --check-only
 ```
+
+There is **no working CLI**. `tasmota_updater.py` is a deprecation stub that
+prints a notice to stderr and exits 1 — `-f/--file`, `--dry-run`,
+`--check-only`, `--update-all` and `--example` are all gone. For scripting, use
+the REST API (`POST /api/update`, `POST /api/update/all`, `GET /api/jobs/<id>`).
+Re-introducing a thin CLI over `app/tasmota` is a backlog item.
 
 ### Environment Setup
 ```bash
@@ -72,11 +69,11 @@ mkdocs build   # Static build
 # Development with fake devices
 ENV_FILE=.env.dev python server.py
 
-# Test CLI with dry run
-python tasmota_updater.py --dry-run
+# Green test core (see "CI, Testing & Gotchas" below)
+pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"
 
-# Example configuration generation
-python tasmota_updater.py --example
+# Playwright e2e suite (needs a GITHUB_TOKEN to avoid GitHub API rate limits)
+pytest tests/e2e -m e2e -o addopts=""
 ```
 
 ## Configuration Files

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ Tasmota Remote Updater is a tool that automatically updates multiple Tasmota dev
 
 ## ✨ Features
 
-**Three powerful interfaces in one tool:**
+**Two supported interfaces in one tool:**
 
-- **Command-Line Interface** *(deprecated)*: superseded by the Web Interface and REST API
 - **Web Interface**: Modern dashboard with one-click updates and real-time monitoring
 - **RESTful API**: Programmatic access with Swagger documentation
+
+The **command-line interface is deprecated** and no longer works — running
+`tasmota_updater.py` only prints a notice and exits. Use the REST API for
+scripting; see [Command-Line Usage](docs/cli-usage.md) for migration notes.
 
 ## 🚀 Quick Start
 

--- a/docs/audit-2026-07/implementation-plan.md
+++ b/docs/audit-2026-07/implementation-plan.md
@@ -58,15 +58,42 @@ Rate-Limiting (schnell) + async Batch (Job-Queue, `202`+Status-Endpoint) +
 Echter Server-Fortschritt statt Fassade; Modal-a11y; Live-Batch-Balken;
 Concurrency-Limit; Bestätigungsdialog mit Geräteliste.
 
-### Phase 4 — CLI reparieren oder deprecaten · #72
-`tasmota_updater.py` ist durch Signatur-Mismatch + Doppel-Definitionen
-funktionsunfähig. Entscheidung: Kernfunktionen wiederverwenden **oder**
-deprecaten.
+### Phase 4 — CLI reparieren oder deprecaten · #72  ✅ erledigt (PR #82)
+`tasmota_updater.py` war durch Signatur-Mismatch + Doppel-Definitionen
+funktionsunfähig. **Entscheidung: deprecaten** — die ~900 Zeilen duplizierten
+die Update-Logik aus `app/tasmota` und waren davon weggelaufen. Heute ist die
+Datei ein Stub (Notice auf stderr, Exit 1).
 
-### Phase 5 — Architektur & Wartbarkeit · #73
+**Offen / Backlog — dünne CLI-Schicht für Automatisierungen.** Der
+Deprecation-Grund war die *Duplikation*, nicht der Nutzen: ein CLI ist für
+Cron/Skripte weiterhin sinnvoll (Wunsch des Users, 2026-07-26). Nachziehen als
+dünner Wrapper **über** dem gepflegten Kern in `app/tasmota` — keine zweite
+Kopie der Logik:
+
+- Optionen wie früher: `-f/--file`, `--check-only`, `--dry-run`, `--update-all`,
+  `--non-interactive`, `--log-level`.
+- Ruft `update_device_firmware()` / den Job-Runner direkt auf, ohne laufenden
+  Server und ohne API-Key (das ist der Vorteil gegenüber `curl` auf die REST-API).
+- Exit-Codes maschinenlesbar (0 = nichts zu tun / alles aktualisiert, ≠ 0 =
+  Fehler), Ausgabe optional als JSON für Weiterverarbeitung.
+- Tests: Unit über den Wrapper (Kern gemockt) + ein Smoke-Lauf gegen Fake-Devices.
+- `docs/cli-usage.md` und die README-Feature-Liste („Three powerful interfaces")
+  wieder in Einklang bringen.
+
+### Phase 5 — Architektur & Wartbarkeit · #73  (teilweise erledigt)
 `updater.py` entflechten; Cache-Locking über Worker; Excepts differenzieren;
-Verifikations-Korrektheit (200 ≠ Erfolg); Credentials via `HTTPBasicAuth`;
 Summary-Zählung.
+
+Zwei Punkte dieser Phase wurden vorgezogen, weil sie als Bugs im Betrieb
+auffielen (v0.5.2, PR #88 / Issue #87):
+
+- ✅ **Verifikations-Korrektheit (200 ≠ Erfolg)** — Tasmota quittiert `Upgrade 1`
+  sofort mit 200 und flasht im Hintergrund weiter auf der alten Firmware.
+  `verify_firmware_version_changed()` wartet jetzt auf die tatsächliche
+  Versionsänderung, statt Erreichbarkeit als Erfolg zu werten.
+- ✅ **Credentials via Basic-Auth statt URL** — `build_device_auth()` übergibt sie
+  am `auth`-Parameter; das Passwort steckt in keiner URL mehr (und ein `:`/`@`
+  im Passwort zerlegt sie nicht länger).
 
 ### Querschnitt — Threat-Model & Doku · #74
 `docs/threat-models/`; README (LAN-only, Klartext-HTTP-Restrisiko);


### PR DESCRIPTION
Reine Doku-Korrektur, kein Code. Ausgelöst durch die Rückfrage „hatten wir nicht gesagt, die CLI-Features werden entfernt? Die README sieht aus, als wären sie noch aktiv."

## Was falsch war

**`CLAUDE.md` widersprach sich selbst.** Zeile 14 sagte „`tasmota_updater.py`: **DEPRECATED** (stub only)", aber:

- Zeile 7 nannte die CLI als einen von drei Wegen ins Programm,
- Zeile 41–48 dokumentierte `python tasmota_updater.py -f devices.yaml`, `--dry-run`, `--check-only` als funktionierende Befehle,
- Zeile 75–79 empfahl `--dry-run` und `--example` zum Testen.

Alle davon laufen in einen Stub mit Exit 1. Wer der Datei folgt, läuft ins Leere — und für eine Datei, deren Zweck es ist, künftige Sessions zu orientieren, ist das der schlimmste Fehlertyp.

**Die README verkaufte „Three powerful interfaces in one tool"**, während eine der drei nicht läuft. Die Deprecation-Markierung stand zwar daneben, aber die Überschrift dominiert — genau daher der Eindruck, die Features seien noch aktiv.

## Änderungen

- `CLAUDE.md`: CLI-Befehle raus, dafür die real nutzbaren Kommandos (grüner Test-Kern, e2e-Suite mit `GITHUB_TOKEN`-Hinweis). Klarer Absatz „There is **no working CLI**" mit Verweis auf die REST-API. Projekt-Übersicht und das „Modular separation"-Pattern sachlich richtiggestellt (die Duplikation war der Grund für die Deprecation).
- `README.md`: „Two supported interfaces", CLI-Status ausgeschrieben statt als Klammerzusatz.
- `docs/audit-2026-07/implementation-plan.md`:
  - **Phase 4 (#72)** als erledigt markiert, mit der getroffenen Entscheidung und dem **Backlog-Eintrag für eine dünne CLI-Schicht** — der Deprecation-Grund war die duplizierte Logik, nicht der Nutzen. Skizziert sind Optionen (`-f/--file`, `--check-only`, `--dry-run`, `--update-all`, `--non-interactive`, `--log-level`), der Aufruf über `app/tasmota` ohne laufenden Server/API-Key, maschinenlesbare Exit-Codes und die Testebene.
  - **Phase 5 (#73):** die zwei Punkte markiert, die als Bugs vorgezogen wurden und mit v0.5.2 gelandet sind — „Verifikations-Korrektheit (200 ≠ Erfolg)" und „Credentials via Basic-Auth statt URL". Beide standen schon im Audit; #87/#88 haben sie eingeholt.

## Prüfung

- Fences paarweise: `CLAUDE.md` 10, `README.md` 6 (der Check aus #90 angewandt).
- Grüner Kern unverändert: 75 passed, 1 skipped.
