### PR TITLE
ci: let a GitHub App author the release PR so its checks actually run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,34 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Release PRs must not be authored by GITHUB_TOKEN. GitHub deliberately
+      # does not run workflows for what that token creates ("events triggered by
+      # the GITHUB_TOKEN will not create a new workflow run"), so the required
+      # pytest checks never report on the release PR and it stays unmergeable
+      # until someone manually approves the parked workflow run — every release.
+      # A GitHub App is a separate identity, so CI runs on its PRs normally.
+      #
+      # Enable by setting both:
+      #   vars.RELEASE_APP_CLIENT_ID       (repository variable, not secret)
+      #   secrets.RELEASE_APP_PRIVATE_KEY  (repository secret)
+      # The App needs only Contents: R/W and Pull requests: R/W.
+      #
+      # Until the variable is set this step is skipped and the job falls back to
+      # GITHUB_TOKEN, i.e. the previous behaviour — so this is safe to merge
+      # before the App exists.
+      - name: Mint a GitHub App token
+        id: app-token
+        if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.windsurf/workflows/release-version.md
+++ b/.windsurf/workflows/release-version.md
@@ -25,6 +25,60 @@ version-bump / tag / `gh release create` step anymore.
    *Publish Container Image* workflow for the new tag so the versioned container
    image is built.
 
+## Who authors the release PR (and why it matters)
+
+GitHub deliberately does not run workflows for anything the built-in
+`GITHUB_TOKEN` creates — "events triggered by the `GITHUB_TOKEN` will not create
+a new workflow run" — to prevent recursive runs. A release PR authored that way
+therefore never gets its `pytest (3.10/3.11/3.12)` runs, and because those are
+required status checks on `main`, the PR is **unmergeable**: the checks are not
+failing, they are missing. `gh pr checks` looks all-green because it only lists
+checks that exist.
+
+The fix is to let a **GitHub App** author the PR — a separate identity, so CI
+runs normally. Set up once:
+
+1. Create a GitHub App (personal or org): *Settings → Developer settings →
+   GitHub Apps → New GitHub App*.
+   - Repository permissions: **Contents: Read & write** and
+     **Pull requests: Read & write**. Nothing else.
+   - No webhook needed (uncheck Active).
+2. Install it on this repository (*Install App*, "Only select repositories").
+3. Generate a private key on the App's settings page (downloads a `.pem`).
+4. In this repository: *Settings → Secrets and variables → Actions*
+   - Variable `RELEASE_APP_CLIENT_ID` = the App's Client ID (not a secret).
+   - Secret `RELEASE_APP_PRIVATE_KEY` = the full contents of the `.pem`.
+
+`release-please.yml` mints a short-lived installation token from these via
+`actions/create-github-app-token` and hands it to release-please. The token is
+revoked when the job ends. **Until `RELEASE_APP_CLIENT_ID` exists the workflow
+falls back to `GITHUB_TOKEN`**, so nothing breaks before the App is configured.
+
+### Fallback: unblocking a release PR without the App
+
+While the App is not set up, each release PR has a parked workflow run that must
+be approved by hand:
+
+```bash
+# find the parked run (conclusion: action_required)
+gh run list --branch release-please--branches--main--components--tasmota-updater --limit 5
+
+gh api -X POST repos/dodjango/tasmota-auto-updater/actions/runs/<id>/approve
+```
+
+If the PR is also `BEHIND` (the `main` ruleset is strict), update the branch
+**first** — the update creates a new commit and therefore a new parked run, so
+approving before updating is wasted.
+
+### Known follow-up: duplicate container publish
+
+Once the App creates the tags, the tag push itself triggers
+*Publish Container Image* (it listens on `push: tags: ['v*']`). The explicit
+`gh workflow run` dispatch in `release-please.yml` was only needed because
+`GITHUB_TOKEN` tags do not trigger anything, so the first App-driven release will
+likely publish the image **twice** (same content, harmless but wasteful). Verify
+the tag-triggered run happens, then remove the dispatch step.
+
 ## Version source of truth
 
 `app/version.py` (`__version__`) is what the app serves at `/version`.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Then visit http://localhost:5001 in your browser.
 - [Configuration Options](docs/configuration.md)
 - [Container Setup](docs/container-setup.md)
 - [Development Guide](docs/development.md)
+- [Releasing](docs/releasing.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Versioning](#versioning)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,5 @@ This documentation will guide you through:
 - [API](api.md) - API documentation for developers
 - [Container Setup](container-setup.md) - Docker/Podman deployment
 - [Development](development.md) - Contributing to the project
+- [Releasing](releasing.md) - How releases are cut (automated via release-please)
 - [Troubleshooting](troubleshooting.md) - Common issues and solutions

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,3 @@
----
-description: How releases work (automated via release-please)
----
-
 # Releasing a New Version
 
 Releases are **fully automated** by [release-please](https://github.com/googleapis/release-please)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - CLI Usage: cli-usage.md
     - API: api.md
   - Development: development.md
+  - Releasing: releasing.md
   - Troubleshooting: troubleshooting.md
   - Contributing: contributing.md
 


### PR DESCRIPTION
Löst das Bot-PR-Gate dauerhaft. Der Dispatch-Workaround bleibt bewusst drin (getrennter Schritt, siehe unten).

## Warum

Release-PRs entstehen mit dem eingebauten `GITHUB_TOKEN`, und GitHub führt für alles, was dieses Token erzeugt, **keine Workflows aus** — Rekursionsschutz, so dokumentiert in der release-please-Action:

> „When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run."

Folge: Die Checks `pytest (3.10/3.11/3.12)` melden am Release-PR **nie**. Da sie auf `main` required sind, ist der PR unmergebar — und zwar besonders unangenehm, weil sie nicht *rot* sind, sondern **fehlen**. `gh pr checks` zeigt „alles grün", weil es nur existierende Checks auflistet. Bei jedem Release derselbe manuelle Freigabe-Tanz.

## Änderung

`actions/create-github-app-token@v3` erzeugt pro Lauf ein **kurzlebiges** Installations-Token (wird am Job-Ende automatisch widerrufen), das an release-please geht. Die App ist eine eigene Identität → CI läuft auf ihren PRs normal.

```yaml
- name: Mint a GitHub App token
  id: app-token
  if: ${{ vars.RELEASE_APP_CLIENT_ID != '' }}
  uses: actions/create-github-app-token@v3
  with:
    client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
    private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

- uses: googleapis/release-please-action@v4
  with:
    token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
```

**Dieser PR ist gefahrlos mergebar, bevor die App existiert:** Ohne `vars.RELEASE_APP_CLIENT_ID` wird der Schritt übersprungen und das Token fällt auf `GITHUB_TOKEN` zurück — exakt das heutige Verhalten. Kein Zeitfenster, in dem der Release-Pfad kaputt ist.

## Was du einmalig tun musst

Das geht nur interaktiv in den GitHub-Settings:

1. **GitHub App anlegen** (*Settings → Developer settings → GitHub Apps → New GitHub App*)
   - Repository permissions: **Contents: Read & write**, **Pull requests: Read & write** — nichts weiter
   - Webhook: *Active* abwählen
2. **Auf diesem Repo installieren** (*Install App*, „Only select repositories")
3. **Private Key erzeugen** (lädt eine `.pem`)
4. **In diesem Repo** (*Settings → Secrets and variables → Actions*):
   - Variable `RELEASE_APP_CLIENT_ID` = Client ID der App (kein Secret)
   - Secret `RELEASE_APP_PRIVATE_KEY` = kompletter Inhalt der `.pem`

Sobald die Variable gesetzt ist, greift es beim nächsten Release automatisch. Die Schritte stehen auch dauerhaft in `docs/releasing.md`.

## Warum keine PAT

Ein Fine-grained PAT wäre schneller eingerichtet, ist aber ein langlebiges, personengebundenes Credential mit Rotationspflicht, das mit dem Account stirbt. Das App-Token ist kurzlebig und an keine Person gebunden.

## Doku ergänzt

Die Release-Doku erwähnte das Gate bisher überhaupt nicht. Jetzt drin: die Ursache, die Einrichtungs-Checkliste, der Freigabe-Weg für die Übergangszeit (inkl. des Hinweises, dass bei `BEHIND` **erst** der Branch aktualisiert werden muss — das Update erzeugt einen neuen geparkten Lauf, vorher freigeben ist verschenkt) und die Folgeaufgabe unten.

## Folgeaufgabe: doppelter Container-Publish

Beim Vorbereiten aufgefallen und **nicht** in diesem PR gelöst, weil der Dispatch-Workaround getrennt behandelt werden soll:

`publish-container.yml` hört auf `push: tags: ['v*']`. Der explizite `gh workflow run`-Dispatch existiert nur, weil `GITHUB_TOKEN`-Tags nichts triggern. Sobald die App die Tags erzeugt, **triggert der Tag-Push den Publish selbst** — der erste App-getriebene Release baut das Image also voraussichtlich **zweimal**.

Bewusst so belassen: doppelt publizieren ist harmlos (gleicher Inhalt, nur Verschwendung), *nicht* publizieren wäre schmerzhaft. Also erst am echten Release verifizieren, dass der Tag-Trigger greift, dann den Dispatch-Schritt in einem eigenen PR entfernen (samt `actions: write`-Permission und dem `--repo`-Fix aus #67).

## Prüfung

- YAML geparst, Step-Reihenfolge und `if`/`token`-Ausdruck kontrolliert.
- Grüner Kern unverändert: 75 passed, 1 skipped (Workflow-/Doku-Änderung).
- Nicht verifizierbar ohne die Secrets: dass das App-Token tatsächlich greift. Das zeigt sich erst am ersten Release nach dem Setup — der Fallback stellt sicher, dass bis dahin nichts kaputt ist.

## Nachtrag: Release-Doku umgezogen

Windsurf ist abgekündigt, `.windsurf/` fliegt bald raus — und die Anleitung, die du für das Setup brauchst, lag genau dort. Daher in diesem PR mit umgezogen:

`.windsurf/workflows/release-version.md` → **`docs/releasing.md`**, Windsurf-Frontmatter entfernt (wäre in die gerenderte Seite geleakt), eingehängt in MkDocs-Nav, `docs/index.md` und die README-Doku-Liste. Mit `mkdocs build --strict` verifiziert.

Die übrigen `.windsurf/workflows`-Dateien (`create-pr`, `generate-commit-message`, `new-bugfix-branch`, `new-feature-branch`) bleiben dem dedizierten Aufräum-PR vorbehalten — deshalb stimmt der Verzeichnis-Hinweis in `docs/development.md` weiterhin.
