### PR TITLE
docs: capture this session's gotchas in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ devices:
 ### Security Considerations
 - All password/credential logging is sanitized via `sanitize_log_data()`
 - Authentication credentials never appear in logs
-- URL passwords masked in log output
+- Device credentials go in the request's `auth` (`build_device_auth()`), never in the URL — `build_device_url()` deliberately returns a credential-free URL. Re-embedding `user:pass@host` breaks passwords containing `:`/`@` and makes CodeQL taint every device response, so any logged firmware version reports as clear-text password logging. `sanitize_log_data()`'s URL masking is the second line of defence, not the first.
 - Follows OWASP security logging guidelines
 
 ### API Structure
@@ -135,12 +135,16 @@ When making changes:
 ## CI, Testing & Gotchas
 
 - **Tests:** `pyproject.toml` is the single pytest config (don't add a second). Green core: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`. `stale` = outdated-vs-code tests (excluded; backlog #63).
-- **E2E:** `tests/e2e/` = pytest-playwright against a subprocess app with fake devices (`DEVICES_FILE=devices-dev.yaml`); separate CI job (chromium cached at `~/.cache/ms-playwright`).
+- **E2E:** `tests/e2e/` = pytest-playwright against a subprocess app with fake devices (`DEVICES_FILE=devices-dev.yaml`); separate CI job (chromium cached at `~/.cache/ms-playwright`). Needs `GITHUB_TOKEN`: the app resolves the latest Tasmota release live on every start (its cache is gitignored, so CI is always cold) and unauthenticated it hits 60 req/h per IP — on a 403 no device "needs" an update and the update-flow tests fail with a misleading timeout. The suite also assumes the real latest version is newer than the fake devices'; prefer stubbing the check via `page.route` (#76).
 - **Required checks on `main`:** CodeQL + `pytest (3.10/3.11/3.12)` (e2e not yet required).
-- **release-please:** squash-merge PR titles MUST be valid conventional commits or no release is cut. Release PRs are bot-authored → approve their `action_required` Tests run (`gh api -X POST repos/<r>/actions/runs/<id>/approve`) before required checks report; if a bot-PR's later pushes don't trigger CI, `gh pr close` + `gh pr reopen` re-triggers it.
+- **Tasmota OTA:** `Upgrade 1` returns HTTP 200 *immediately* and flashes in the background while still serving the OLD firmware; the reboot follows seconds-to-minutes later. Reachability is NOT completion — `verify_firmware_version_changed()` polls until the reported version actually changes before success is reported (#87). The client timeout for `POST /api/update` must stay above the server's `total_timeout` (default 240s).
+- **release-please:** squash-merge PR titles MUST be valid conventional commits or no release is cut. Release PRs are authored by the `tasmota-updater-release-bot` GitHub App (`vars.RELEASE_APP_CLIENT_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`), so their checks run normally — see `docs/releasing.md`. Without it the PR is `GITHUB_TOKEN`-authored and its Tests run parks as `action_required`: the required checks are then **missing, not failing**, and `gh pr checks` looks all-green because it only lists checks that exist. If a bot-PR's later pushes don't trigger CI, `gh pr close` + `gh pr reopen` re-triggers it.
 - **CI flakiness:** a runner job occasionally sticks in `in_progress` while its run shows `completed` → re-run just that job with `gh run rerun --job <id>`.
 - **Runtime:** single gthread Gunicorn worker (`gunicorn.conf.py`) required — the batch-job store (`app/tasmota/jobs.py`) is in-memory. Batch updates async: `POST /api/update/all` → `202 {job_id}`, poll `GET /api/jobs/<id>`; single `POST /api/update` still sync. `SESSION_COOKIE_SECURE=false` for plain-HTTP LAN.
 - **Frontend/UI:** after a device-changing action, refresh `device.status` via `fetchDeviceStatus()`/`refreshDevices()` — updating only `device.update_status` leaves the card's version/tag stale (fix #84). The batch path already re-fetches via `refreshDevices()`.
+- **UI honesty:** `needs_update: false` also means "could not compare" (failed release lookup → `latest_version: "Unknown"`). Gate "Up to Date"/"Update Available" on `isVersionComparisonKnown(device)` — keyed on `latest_version`, NOT on `success`, because a failed *update* still carries a known latest version (#91).
+- **Alpine + Playwright:** `x-show` only toggles `display`; elements stay in the DOM. Assert `to_be_visible()`/`to_be_hidden()`, never `to_have_count(0)`.
+- **Misc:** a branch named `docs` exists, so `docs/…` branch names are rejected ("directory file conflict") → use `chore/…`. Verify doc links with `mkdocs build --strict`. For a CodeQL finding, pull the real dataflow path from the SARIF (`gh api …/code-scanning/analyses/<id> -H "Accept: application/sarif+json"` → `codeFlows`) instead of guessing at the taint source.
 - **Env:** corporate TLS proxy blocks external npm/CDN fetches (no release-please dry-run, no SRI/`playwright install` from scratch); pip/uv work.
 
 The application supports development without physical Tasmota devices through the fake device system, allowing full feature testing in isolation.


### PR DESCRIPTION
docs: capture this session's gotchas in CLAUDE.md

Six things that cost real time and were not written down anywhere:

- Device credentials now travel in the request's `auth`, never in the URL. The
  old line claimed URL passwords are "masked in log output", which is
  misleading now and would invite a regression that both breaks passwords
  containing ':'/'@' and floods CodeQL with clear-text-logging findings.
- Tasmota answers `Upgrade 1` with HTTP 200 while still running the old
  firmware, so reachability is not completion. Without this the #87 bug goes
  straight back in.
- The e2e suite resolves the latest Tasmota release live and needs a
  GITHUB_TOKEN; a rate-limited lookup makes every device look up to date and
  the update-flow test fail with an unrelated-looking timeout.
- `needs_update: false` also means "could not compare", hence the
  latest_version-keyed gate from #91 — and deliberately not a success-keyed one.
- `x-show` leaves elements in the DOM, so Playwright must assert visibility
  rather than element count.
- release-please PRs now come from a GitHub App, so the per-release approve
  dance is gone; recorded together with the trap that missing required checks
  read as all-green in `gh pr checks`.

Plus a few small tool facts: `docs/…` branch names are rejected because a
branch named `docs` exists, `mkdocs build --strict` checks doc links, and a
CodeQL finding's real dataflow path comes from the SARIF instead of guesswork.
