### PR TITLE
ci(deps): squash-merge dependabot PRs and bump fetch-metadata to v3

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,12 @@ name: Dependabot Auto-Merge
 # left open with a comment for manual review. No version.py bump happens here
 # anymore — that caused every PR to touch the same line and conflict, which
 # stalled the whole queue. App version bumps belong to the release process.
+#
+# Heads-up: enabling auto-merge is not the same as merging. The `main` ruleset
+# requires the three CodeQL `Analyze (...)` checks, and CodeQL default setup
+# does not produce them on Dependabot PRs ("3 configurations not found"), so a
+# queued auto-merge waits forever. Until that is resolved, Dependabot bumps
+# still have to be consolidated into a human-authored PR.
 
 on: pull_request
 
@@ -19,15 +25,20 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # --squash, not --merge: the `main` ruleset requires linear history, so
+      # enabling auto-merge with a merge commit fails outright with
+      # "Merge method merge commits are not allowed on this repository".
+      # Squash is also what release-please needs — the squash title is the
+      # conventional commit it reads.
       - name: Enable auto-merge for patch and minor updates
         if: >-
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Der eigentliche Grund für den aktuellen Dependabot-Stau.**

`dependabot-auto-merge.yml` rief `gh pr merge --auto --merge`. Das scheitert bei *jedem* eligible PR:

```
GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)
```

Ursache ist nicht das Repo-Setting (`allow_merge_commit` ist `true`), sondern die Regel `required_linear_history` im `main`-Ruleset. Die Dependabot-Metadaten waren immer korrekt (`semver-patch`, `maintainer-changes: false`) — es hakte erst am Merge-Aufruf. Jetzt `--squash`, was ohnehin die richtige Methode ist: release-please liest den Squash-Titel als Conventional Commit.

Dazu **dependabot/fetch-metadata 2 → 3** (#106, reiner Node-24-Bump, keine Input-Änderungen) — behebt zugleich die `Node.js 20 is deprecated`-Warnung in genau diesem Job.

## Wichtig: das reicht noch nicht

Auto-Merge *aktivieren* ist nicht Auto-Merge *ausführen*. Das `main`-Ruleset verlangt sechs Checks, darunter `Analyze (actions)`, `Analyze (javascript-typescript)` und `Analyze (python)`. Auf Dependabot-PRs erscheinen die **nicht**:

```
CodeQL  conclusion=neutral  app=github-advanced-security  title="3 configurations not found"
```

Auf menschlichen PRs (#97, #100) laufen alle drei grün. Heißt: Dependabot-PRs erfüllen 3 von 6 Required Checks nie, ein aktivierter Auto-Merge wartet ewig, und auch manuelles Mergen geht nur mit Bypass. Deshalb steht das als Kommentar im Workflow-Header — und deshalb werden die aktuellen Bumps in konsolidierten, von Hand aufgemachten PRs nachgezogen statt einzeln gemergt.

Closes #106
