### PR TITLE
ci: replace CodeQL default setup with an advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: CodeQL
+
+# Advanced setup, deliberately replacing CodeQL *default* setup.
+#
+# Default setup does not run on Dependabot PRs (github/codeql-action#2858): the
+# aggregate check reports "3 configurations not found" with a neutral
+# conclusion and the three `Analyze (...)` jobs never appear. Since those three
+# are required contexts on `main`, every Dependabot PR was missing half its
+# required checks — unmergeable, with auto-merge queued forever. As a normal
+# workflow the analysis runs on Dependabot PRs like any other job.
+#
+# The job name is kept byte-identical to the default-setup check names
+# (`Analyze (actions)`, `Analyze (javascript-typescript)`, `Analyze (python)`)
+# so the ruleset contexts keep matching. Do not rename it without updating the
+# ruleset in the same breath.
+#
+# Mirrors what default setup was configured with: same three languages, default
+# query suite, weekly schedule.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, same cadence the default setup used.
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      # Required to upload the SARIF results, including on Dependabot PRs,
+      # where the token is read-only unless a job asks for more.
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # `javascript-typescript` covers both JS and TS — that is why default
+        # setup produced three checks, not five, for its five listed languages.
+        language: [actions, javascript-typescript, python]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Schritt 1 des abgestimmten Wegs: CodeQL vom **Default**- aufs **Advanced**-Setup.

## Warum

Default-Setup läuft nicht auf Dependabot-PRs ([github/codeql-action#2858](https://github.com/github/codeql-action/issues/2858)). Der Aggregat-Check meldet dort `conclusion=neutral, title="3 configurations not found"`, die drei `Analyze (...)`-Jobs erscheinen gar nicht. Da genau die im `main`-Ruleset Required sind, fehlten Dependabot-PRs dauerhaft 3 von 6 Checks: nicht rot, sondern **abwesend** — ein aktivierter Auto-Merge wartet ewig auf etwas, das nie kommt. Als normaler Workflow läuft die Analyse dort wie jeder andere Job, und Dependabot-PRs bekommen zum ersten Mal überhaupt Code-Scanning.

## Was drin ist

Spiegelt exakt, was das Default-Setup konfiguriert hatte: dieselben drei Sprachen (`actions`, `javascript-typescript`, `python` — `javascript-typescript` deckt JS und TS ab, deshalb waren es drei Checks und nicht fünf), Default-Query-Suite, wöchentlicher Lauf.

Der Job-Name ist **zeichengleich** zu den Default-Setup-Check-Namen (`Analyze (actions)` usw.), damit die Ruleset-Kontexte weiter matchen. Steht auch als Warnung im Workflow-Kommentar: nicht umbenennen, ohne das Ruleset im selben Zug anzufassen.

`security-events: write` ist explizit gesetzt — auf Dependabot-PRs ist der Token sonst read-only und der SARIF-Upload scheitert.

## Reihenfolge — hier brauche ich dich

Ich komme an die Repo-Settings nicht heran: `PATCH .../rulesets/6835103` und `PATCH .../code-scanning/default-setup` geben **404**, auch bei minimalem Payload, obwohl `gh` als `dodjango` mit `admin: true` und `repo`-Scope angemeldet ist. Klassische Tokens brauchen für Code-Scanning zusätzlich `security_events`, und Ruleset-Writes akzeptiert GitHub offenbar nur mit feingranularem Token („Administration: write") — GET funktioniert in beiden Fällen.

Deshalb, bitte in dieser Reihenfolge:

1. **Default-Setup abschalten** — *Settings → Code security → CodeQL analysis → Default setup → Disable*. Solange es an ist, erzeugen beide Konfigurationen dieselben Check-Namen.
2. Diesen PR **neu laufen lassen** (leerer Commit oder `gh pr close`/`reopen`) und prüfen, dass `Analyze (actions|javascript-typescript|python)` kommen — jetzt aus diesem Workflow — und grün sind.
3. Mergen.
4. Beim **nächsten Dependabot-PR** nachsehen, ob die drei Jobs dort laufen. Wenn ja, ist das Thema durch und Auto-Merge funktioniert. Wenn der SARIF-Upload am read-only-Token scheitert, nehmen wir die drei Kontexte vorübergehend aus der Required-Liste — dafür liegt ein Backup des Rulesets bereit.

Ein Ruleset-Backup habe ich vor dem ersten PATCH-Versuch gezogen, falls doch etwas verstellt werden muss.
