### PR TITLE
fix(ci): make dependabot.yml schema-valid again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,17 @@ version: 2
 # misreported as `directory: /main`.
 #
 # The groups below bundle patch+minor per ecosystem into one weekly PR; majors
-# stay separate for individual review. On 2026-07-26 the grouping did not take
-# effect (14 individual PRs, `dependency-group` empty in every metadata set)
-# even though the run was the scheduled one and none of them were security
-# updates. `applies-to` is now explicit; whether that was the cause will only
-# show on the next wave of bumps.
+# stay separate for individual review.
+#
+# They never took effect, and the reason was not the group syntax: this file
+# had been schema-invalid since the very commit that introduced the groups
+# (2026-07-22), because `versioning-strategy` is not allowed for the docker
+# ecosystem. Dependabot reported that on its `.github/dependabot.yml` check —
+# a check that only re-runs when this file changes, so nobody saw it for days
+# while the scheduled runs quietly fell back to one PR per dependency.
+#
+# Lesson: after editing this file, look at the `.github/dependabot.yml` check
+# on the commit. A silently ignored config looks exactly like a working one.
 
 updates:
   # Check for updates to Python packages
@@ -92,7 +98,6 @@ updates:
       - "dodjango"
     reviewers:
       - "dodjango"
-    versioning-strategy: "auto"
     groups:
       docker-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
**Das ist die Antwort auf die Gruppierungsfrage** — und sie ist unangenehmer als gedacht.

Dependabot meldet auf seinem eigenen Check `.github/dependabot.yml`:

```
The property '#/updates/2/' contains additional properties
["versioning-strategy"] outside of the schema when none are allowed
```

`versioning-strategy` gibt es für das **docker**-Ökosystem nicht. Damit war die Datei ungültig — **seit 2026-07-22, also seit genau dem Commit, der die `groups` eingeführt hat** (#62). Ich habe es an `6d4ea4e` gegengeprüft: dort ist derselbe Check schon rot.

Damit fällt die offene Frage aus #119 weg: die Gruppierung hat nicht versagt, die Konfiguration wurde nie angewendet. Die planmäßigen Läufe sind auf das Default-Verhalten zurückgefallen — ein PR pro Abhängigkeit, so wie am 2026-07-26 die 14 Stück entstanden sind.

Warum das tagelang niemandem auffiel: der Check läuft **nur, wenn diese Datei sich ändert**. Zwischen #62 und #119 hat sie niemand angefasst, also stand die Fehlermeldung an einem Commit, den keiner mehr angesehen hat. Eine still ignorierte Config sieht von außen exakt aus wie eine funktionierende. Das steht jetzt als Warnung im Header-Kommentar.

Ob die Gruppen jetzt wirklich greifen, zeigt die nächste Bump-Welle — aber diesmal ist die Datei nachweislich gültig, der Check auf diesem PR ist der Beleg.
