### PR TITLE
ci: drop the container-publish dispatch workaround

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,11 @@ name: release-please
 
 # Automates releases via conventional commits. On every push to main,
 # release-please maintains a release PR (version bump + CHANGELOG). Merging that
-# PR creates the git tag + GitHub release, and then triggers the container
-# publish for the new tag (GITHUB_TOKEN-created tags do not trigger workflows on
-# their own, so we dispatch publish-container explicitly).
+# PR creates the git tag + GitHub release, and the tag push triggers
+# publish-container on its own: the tag is created by the GitHub App, not by
+# GITHUB_TOKEN, so it does start workflows. The explicit `gh workflow run`
+# dispatch that used to sit here was left over from the GITHUB_TOKEN era and
+# built every release container a second time (verified on v0.5.4).
 
 on:
   push:
@@ -13,7 +15,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 jobs:
   release-please:
@@ -49,10 +50,3 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Trigger container publish for the new tag
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run "Publish Container Image" --repo "$GITHUB_REPOSITORY" --ref "$TAG"


### PR DESCRIPTION
Der offene Audit-Punkt, jetzt mit Beleg statt Vermutung.

Der Schritt `gh workflow run "Publish Container Image"` existierte, weil Tags, die mit `GITHUB_TOKEN` erzeugt werden, keine Workflows auslösen. Seit die GitHub App `tasmota-updater-release-bot` den Release-PR und damit den Tag erzeugt, triggert der Tag-Push `publish-container` von allein — der Dispatch baute obendrauf ein zweites, identisches Image.

**Gemessen am Release v0.5.4** (heute, 18:38 UTC): drei Läufe von *Publish Container Image*, zwei davon für denselben Tag.

```
18:38:47  event=workflow_dispatch  ref=v0.5.4   ← dieser Schritt
18:38:44  event=push               ref=v0.5.4   ← der Tag-Trigger
18:38:35  event=push               ref=main     ← 'latest', so gewollt
```

Mit dem Schritt fällt auch die Berechtigung `actions: write` weg, die der Job sonst nur dafür brauchte. Der Header-Kommentar erklärt jetzt den Ist-Zustand statt der alten `GITHUB_TOKEN`-Begründung.

**Beweis erst beim nächsten Release:** dass danach genau zwei Läufe bleiben (`main` für `latest`, Tag für die Version), zeigt sich naturgemäß erst dann. Falls der Tag-Trigger doch ausfällt, wäre das Symptom ein fehlendes Versions-Image bei vorhandenem `latest`.

Zum selben Release-Durchlauf noch zwei bestätigte Nebenbefunde: **release-please-action v5** hat Tag und Release korrekt erzeugt, und die sechs Required Checks liefen auf dem Bot-PR normal — inklusive der drei `Analyze`-Jobs aus dem neuen CodeQL-Advanced-Setup.
