### PR TITLE
feat(cli): add a thin CLI over the maintained core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ compose.yml
 # Flask stuff:
 instance/
 .webassets-cache
+
+# Superpowers SDD scratch workspace (ledger, briefs, review packages)
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Tasmota Remote Updater is a Python Flask application that allows remote updating of multiple Tasmota devices via a web interface and a REST API. The application follows a modular architecture with separate components for core functionality, web interface, and API endpoints. (A CLI existed but is deprecated — see below.)
+Tasmota Remote Updater is a Python Flask application that allows remote updating of multiple Tasmota devices via a web interface, a REST API, and a thin CLI. The application follows a modular architecture with separate components for core functionality, web interface, API endpoints, and the CLI wrapper.
 
 ## Core Architecture
 
 ### Application Structure
 - **Entry Points**:
   - `server.py`: Flask web application with Swagger API documentation
-  - `tasmota_updater.py`: Command-line interface — **DEPRECATED** (stub only; use web UI / REST API)
+  - `app/cli.py`: Command-line interface — thin wrapper over `app/tasmota`, invoked as `python -m app.cli`
+  - `tasmota_updater.py`: Retired entry point — stub only, points at `app/cli.py`
   - `wsgi.py`: WSGI entry point for production deployment
 
 - **Core Module** (`app/tasmota/`):
@@ -23,7 +24,7 @@ Tasmota Remote Updater is a Python Flask application that allows remote updating
 - **Configuration**: YAML-based device configuration with support for authentication and fake devices for testing
 
 ### Key Design Patterns
-- **Modular separation**: the update logic lives in `app/tasmota` and is shared by the web UI and the API (no duplicated copies — that duplication is exactly what killed the CLI)
+- **Modular separation**: the update logic lives in `app/tasmota` and is shared by the web UI, the API and the CLI (no duplicated copies — that duplication is exactly what killed the old CLI)
 - **Security-first**: Credential sanitization in logs, no sensitive data exposure
 - **Fake device support**: Development mode with simulated devices for testing
 - **Environment-based configuration**: `.env` files for different deployment scenarios
@@ -39,11 +40,27 @@ python server.py
 ENV_FILE=.env.dev python server.py
 ```
 
-There is **no working CLI**. `tasmota_updater.py` is a deprecation stub that
-prints a notice to stderr and exits 1 — `-f/--file`, `--dry-run`,
-`--check-only`, `--update-all` and `--example` are all gone. For scripting, use
-the REST API (`POST /api/update`, `POST /api/update/all`, `GET /api/jobs/<id>`).
-Re-introducing a thin CLI over `app/tasmota` is a backlog item.
+```bash
+# CLI: check, update, or list — not installed as a package, always via -m
+python -m app.cli check
+python -m app.cli update --timeout 300
+python -m app.cli list --json
+```
+
+The CLI has three verbs — `check`, `update`, `list` — and is a **thin wrapper
+only**: it resolves the device list and calls into `app/tasmota` (the batch
+job runner and `updater.get_device_firmware_version()`), the same code path
+the web UI and the REST API use. It must never grow its own update logic —
+that duplication, and the resulting drift, is what killed the old
+`tasmota_updater.py`. Exit codes are the contract for automation: `0` ok, `1`
+outdated (`check` only), `2` error; on mixed results the higher code wins. A
+failed release lookup is an error, never "up to date" (see #91's CLI twin).
+Details, the option table and cron examples: `docs/cli-usage.md`.
+
+`tasmota_updater.py` itself is a retired stub: it prints a notice pointing at
+`python -m app.cli` and exits 1. Its old options (`-f/--file` aside,
+`--dry-run`, `--check-only`, `--update-all`, `--example`) do not exist on the
+new CLI.
 
 ### Environment Setup
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,14 +12,11 @@ Tasmota Remote Updater is a tool that automatically updates multiple Tasmota dev
 
 ## ✨ Features
 
-**Two supported interfaces in one tool:**
+**Three supported interfaces in one tool:**
 
 - **Web Interface**: Modern dashboard with one-click updates and real-time monitoring
 - **RESTful API**: Programmatic access with Swagger documentation
-
-The **command-line interface is deprecated** and no longer works — running
-`tasmota_updater.py` only prints a notice and exits. Use the REST API for
-scripting; see [Command-Line Usage](docs/cli-usage.md) for migration notes.
+- **Command-Line Interface**: A thin `python -m app.cli` wrapper for cron jobs and scripting — see [Command-Line Usage](docs/cli-usage.md)
 
 ## 🚀 Quick Start
 
@@ -83,7 +80,7 @@ Then visit http://localhost:5001 in your browser.
 ## 📚 Documentation
 
 - [Installation Guide](docs/installation.md)
-- [Command-Line Usage](docs/cli-usage.md) *(deprecated)*
+- [Command-Line Usage](docs/cli-usage.md)
 - [Web Interface Guide](docs/web-interface.md)
 - [API Documentation](docs/api.md)
 - [Configuration Options](docs/configuration.md)

--- a/app/cli.py
+++ b/app/cli.py
@@ -143,6 +143,11 @@ _CHECK_LABELS = {
 }
 
 
+def _list_label(result: Mapping[str, Any]) -> str:
+    """`list` performs no release lookup, so no comparison wording applies."""
+    return "" if result.get("success") else "nicht erreichbar"
+
+
 def _update_label(result: Mapping[str, Any]) -> str:
     """Label for an update run. A just-updated device still carries
     ``needs_update`` from its pre-update comparison, so the class alone lies."""
@@ -192,11 +197,17 @@ def render_human(
     """One line per device plus a closing tally, sized for a cron mail."""
     lines = []
     for result in results:
-        label = _update_label(result) if command == "update" else _CHECK_LABELS[classify(result)]
+        if command == "update":
+            label = _update_label(result)
+        elif command == "list":
+            label = _list_label(result)
+        else:
+            label = _CHECK_LABELS[classify(result)]
         name = str(result.get("dns_name") or "")
-        lines.append(
+        line = (
             f"{str(result.get('ip', '?')):<16}{name:<16}{_version_column(result):<20}{label}"
         )
+        lines.append(line.rstrip())
     lines.append(_tally_line(command, summary))
     return "\n".join(lines)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -7,6 +7,7 @@ killed the previous CLI (Phase 4 of the 2026-07 audit).
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -132,3 +133,87 @@ def exit_code_for(command: str, summary: Mapping[str, int]) -> int:
     if command == "check" and summary.get("needs_update"):
         return EXIT_OUTDATED
     return EXIT_OK
+
+
+_CHECK_LABELS = {
+    "failed": "nicht erreichbar",
+    "comparison_unknown": "Vergleich unbekannt",
+    "needs_update": "Update verfügbar",
+    "up_to_date": "aktuell",
+}
+
+
+def _update_label(result: Mapping[str, Any]) -> str:
+    """Label for an update run. A just-updated device still carries
+    ``needs_update`` from its pre-update comparison, so the class alone lies."""
+    if result.get("update_completed"):
+        return "aktualisiert"
+    if not result.get("success"):
+        return "Update fehlgeschlagen" if result.get("update_started") else "nicht erreichbar"
+    if classify(result) == "comparison_unknown":
+        return "Vergleich unbekannt"
+    return "übersprungen (aktuell)"
+
+
+def _version_column(result: Mapping[str, Any]) -> str:
+    """Format the version column: current, current→latest, or —."""
+    current = result.get("current_version") or "—"
+    if not result.get("success"):
+        return "—"
+    if classify(result) == "needs_update":
+        return f"{current} → {result.get('latest_version')}"
+    return str(current)
+
+
+def _tally_line(command: str, summary: Mapping[str, int]) -> str:
+    """Format the summary line, tailored to the command."""
+    if command == "list":
+        return f"{summary.get('total', 0)} Geräte, {summary.get('failed', 0)} Fehler"
+    if command == "update":
+        return (
+            f"{summary.get('updated', 0)} aktualisiert, "
+            f"{summary.get('skipped', 0)} übersprungen, "
+            f"{summary.get('comparison_unknown', 0)} Vergleich unbekannt, "
+            f"{summary.get('failed', 0)} Fehler"
+        )
+    return (
+        f"{summary.get('up_to_date', 0)} aktuell, "
+        f"{summary.get('needs_update', 0)} Update verfügbar, "
+        f"{summary.get('comparison_unknown', 0)} Vergleich unbekannt, "
+        f"{summary.get('failed', 0)} Fehler"
+    )
+
+
+def render_human(
+    command: str,
+    results: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, int],
+) -> str:
+    """One line per device plus a closing tally, sized for a cron mail."""
+    lines = []
+    for result in results:
+        label = _update_label(result) if command == "update" else _CHECK_LABELS[classify(result)]
+        name = str(result.get("dns_name") or "")
+        lines.append(
+            f"{str(result.get('ip', '?')):<16}{name:<16}{_version_column(result):<20}{label}"
+        )
+    lines.append(_tally_line(command, summary))
+    return "\n".join(lines)
+
+
+def render_json(
+    command: str,
+    devices_file: str,
+    results: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, int],
+    exit_code: int,
+) -> str:
+    """Emit the core result dicts unchanged, plus tally and exit code."""
+    payload = {
+        "command": command,
+        "devices_file": devices_file,
+        "results": [dict(result) for result in results],
+        "summary": dict(summary),
+        "exit_code": exit_code,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)

--- a/app/cli.py
+++ b/app/cli.py
@@ -270,6 +270,44 @@ def cmd_check(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     return run_batch(devices, check_only=True, timeout=None)
 
 
+def cmd_update(
+    devices: Sequence[Mapping[str, Any]],
+    *,
+    force: bool,
+    timeout: int | None,
+) -> list[dict[str, Any]]:
+    """Update outdated devices in two passes: classify, then flash the subset.
+
+    The runner's own ``update_only_needed`` filter is not used: it drops
+    skipped devices from the results, which would make a failed release lookup
+    indistinguishable from "everything current".
+    """
+    checked = run_batch(devices, check_only=True, timeout=None)
+    # With --force, up-to-date devices are flashed too — but never a device we
+    # could not classify: flashing blind is worse than doing nothing.
+    wanted = ("needs_update", "up_to_date") if force else ("needs_update",)
+    selected_ips = [result["ip"] for result in checked if classify(result) in wanted]
+    if not selected_ips:
+        return checked
+
+    by_ip = {device.get("ip"): device for device in devices}
+    subset = [by_ip[ip] for ip in selected_ips if ip in by_ip]
+    updated = {
+        result.get("ip"): result
+        for result in run_batch(subset, check_only=False, timeout=timeout)
+    }
+    # Every selected device must come back with a pass-two result. Silently
+    # falling back to its pass-one entry would leave it carrying a stale
+    # needs_update flag while landing in none of the tally's buckets — the
+    # totals stop adding up and a device that needed flashing looks untouched.
+    missing = [ip for ip in selected_ips if ip not in updated]
+    if missing:
+        raise CliError(
+            "The update pass returned no result for: " + ", ".join(str(ip) for ip in missing)
+        )
+    return [updated.get(result["ip"], result) for result in checked]
+
+
 def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     """Inventory: what is configured and what firmware runs on it.
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -11,6 +11,8 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from app.tasmota import jobs, updater, utils
+
 EXIT_OK = 0
 EXIT_OUTDATED = 1
 EXIT_ERROR = 2
@@ -228,3 +230,23 @@ def render_json(
         "exit_code": exit_code,
     }
     return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+
+
+def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Inventory: what is configured and what firmware runs on it.
+
+    Deliberately LAN-only — no release lookup, so no GitHub rate limit can
+    break it, and it can never report "outdated".
+    """
+    results: list[dict[str, Any]] = []
+    for device in devices:
+        info = updater.get_device_firmware_version(dict(device))
+        result: dict[str, Any] = {
+            "ip": device.get("ip"),
+            "success": info is not None,
+            "current_version": (info or {}).get("version", UNKNOWN_VERSION),
+        }
+        if device.get("dns_name"):
+            result["dns_name"] = device["dns_name"]
+        results.append(result)
+    return results

--- a/app/cli.py
+++ b/app/cli.py
@@ -64,11 +64,6 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         help="Override the per-device total timeout in seconds.",
     )
-    update.add_argument(
-        "--force",
-        action="store_true",
-        help="Flash every configured device, including up-to-date ones.",
-    )
     return parser
 
 
@@ -85,8 +80,20 @@ def classify(result: Mapping[str, Any]) -> str:
     ``needs_update: False`` also means "could not compare" when the release
     lookup failed, so an unknown ``latest_version`` must be recognised before
     anything is called up to date (#91).
+
+    ``success: False`` is not automatically "failed", either: the core also
+    reports it when the device answered fine but the *release* lookup did
+    not (a GitHub rate limit hits every device at once). That device is
+    reachable — it just could not be compared — so it must not read as
+    "nicht erreichbar", which sends an operator looking at the LAN for
+    nothing. A device that reports no usable current_version at all is a
+    real failure regardless of what latest_version says.
     """
     if not result.get("success"):
+        current = result.get("current_version")
+        latest = result.get("latest_version")
+        if current and current != UNKNOWN_VERSION and (not latest or latest == UNKNOWN_VERSION):
+            return "comparison_unknown"
         return "failed"
     latest = result.get("latest_version")
     if not latest or latest == UNKNOWN_VERSION:
@@ -284,7 +291,6 @@ def cmd_check(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
 def cmd_update(
     devices: Sequence[Mapping[str, Any]],
     *,
-    force: bool,
     timeout: int | None,
 ) -> list[dict[str, Any]]:
     """Update outdated devices in two passes: classify, then flash the subset.
@@ -294,10 +300,7 @@ def cmd_update(
     indistinguishable from "everything current".
     """
     checked = run_batch(devices, check_only=True, timeout=None)
-    # With --force, up-to-date devices are flashed too — but never a device we
-    # could not classify: flashing blind is worse than doing nothing.
-    wanted = ("needs_update", "up_to_date") if force else ("needs_update",)
-    selected_ips = [result["ip"] for result in checked if classify(result) in wanted]
+    selected_ips = [result["ip"] for result in checked if classify(result) == "needs_update"]
     if not selected_ips:
         return checked
 
@@ -319,7 +322,8 @@ def cmd_update(
     missing = [ip for ip in selected_ips if ip not in updated]
     if missing:
         raise CliError(
-            "The update pass returned no result for: " + ", ".join(str(ip) for ip in missing)
+            "The update pass returned no result for, or found no device "
+            "configuration for: " + ", ".join(str(ip) for ip in missing)
         )
     return [updated.get(result["ip"], result) for result in checked]
 
@@ -350,7 +354,9 @@ def _duplicate_ips(devices: Sequence[Mapping[str, Any]]) -> list[Any]:
 
     Two entries sharing an IP would silently collapse inside ``cmd_update``'s
     IP-to-config mapping: one config gets flashed twice with the wrong
-    credentials while the other is never touched.
+    credentials while the other is never touched. ``main()`` calls this
+    before dispatching to any command, so that collapse is a risk this guard
+    forecloses, not a live hazard inside ``cmd_update`` itself.
     """
     counts = Counter(device.get("ip") for device in devices)
     return [ip for ip, count in counts.items() if count > 1]
@@ -387,7 +393,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     devices = utils.load_devices_from_file(devices_file)
     if not devices:
-        print(f"No devices configured in {devices_file}", file=sys.stderr)
+        # load_devices_from_file() swallows its own parse errors and returns
+        # [] either way, so this covers both "no devices configured" and "the
+        # YAML could not be parsed" — check stderr above for the latter.
+        print(
+            f"No devices configured in {devices_file}, or the file could not "
+            "be parsed — see any parser error above.",
+            file=sys.stderr,
+        )
         return EXIT_ERROR
 
     duplicates = _duplicate_ips(devices)
@@ -405,7 +418,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "check":
             results = cmd_check(devices)
         else:
-            results = cmd_update(devices, force=args.force, timeout=args.timeout)
+            results = cmd_update(devices, timeout=args.timeout)
     except CliError as exc:
         print(str(exc), file=sys.stderr)
         return EXIT_ERROR

--- a/app/cli.py
+++ b/app/cli.py
@@ -123,3 +123,12 @@ def summarize(results: Sequence[Mapping[str, Any]], command: str
         "comparison_unknown": unknown,
         "failed": failed,
     }
+
+
+def exit_code_for(command: str, summary: Mapping[str, int]) -> int:
+    """Map a tally to an exit code. Error beats outdated beats ok."""
+    if summary.get("failed") or summary.get("comparison_unknown"):
+        return EXIT_ERROR
+    if command == "check" and summary.get("needs_update"):
+        return EXIT_OUTDATED
+    return EXIT_OK

--- a/app/cli.py
+++ b/app/cli.py
@@ -292,10 +292,15 @@ def cmd_update(
 
     by_ip = {device.get("ip"): device for device in devices}
     subset = [by_ip[ip] for ip in selected_ips if ip in by_ip]
-    updated = {
-        result.get("ip"): result
-        for result in run_batch(subset, check_only=False, timeout=timeout)
-    }
+    # If every selected IP is unmapped, the subset is empty — do not hand that
+    # to the runner and get back a runner-shaped error instead of ours. The
+    # message shape must stay the same however the devices went missing.
+    updated: dict[Any, dict[str, Any]] = {}
+    if subset:
+        updated = {
+            result.get("ip"): result
+            for result in run_batch(subset, check_only=False, timeout=timeout)
+        }
     # Every selected device must come back with a pass-two result. Silently
     # falling back to its pass-one entry would leave it carrying a stale
     # needs_update flag while landing in none of the tally's buckets — the

--- a/app/cli.py
+++ b/app/cli.py
@@ -7,7 +7,8 @@ killed the previous CLI (Phase 4 of the 2026-07 audit).
 from __future__ import annotations
 
 import argparse
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 EXIT_OK = 0
 EXIT_OUTDATED = 1
@@ -68,3 +69,57 @@ def resolve_devices_file(explicit: str | None, env: Mapping[str, str]) -> str:
     if explicit:
         return explicit
     return env.get("DEVICES_FILE", "devices.yaml")
+
+
+def classify(result: Mapping[str, Any]) -> str:
+    """Classify one core result dict. The four classes are mutually exclusive.
+
+    ``needs_update: False`` also means "could not compare" when the release
+    lookup failed, so an unknown ``latest_version`` must be recognised before
+    anything is called up to date (#91).
+    """
+    if not result.get("success"):
+        return "failed"
+    latest = result.get("latest_version")
+    if not latest or latest == UNKNOWN_VERSION:
+        return "comparison_unknown"
+    if result.get("needs_update"):
+        return "needs_update"
+    return "up_to_date"
+
+
+def summarize(results: Sequence[Mapping[str, Any]], command: str
+              ) -> dict[str, int]:
+    """Build the tally for ``command``. Shapes differ per command by design."""
+    classes = [classify(result) for result in results]
+    total = len(results)
+    failed = classes.count("failed")
+    unknown = classes.count("comparison_unknown")
+
+    if command == "list":
+        return {"total": total, "failed": failed}
+
+    if command == "update":
+        updated = sum(1 for result in results if result.get("update_completed"))
+        # A device that was updated successfully now reports the new version and
+        # would classify as up_to_date — it must not be counted as skipped too.
+        skipped = sum(
+            1
+            for result, cls in zip(results, classes, strict=True)
+            if cls == "up_to_date" and not result.get("update_completed")
+        )
+        return {
+            "total": total,
+            "updated": updated,
+            "skipped": skipped,
+            "comparison_unknown": unknown,
+            "failed": failed,
+        }
+
+    return {
+        "total": total,
+        "up_to_date": classes.count("up_to_date"),
+        "needs_update": classes.count("needs_update"),
+        "comparison_unknown": unknown,
+        "failed": failed,
+    }

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,56 @@
+"""Thin command-line wrapper over the maintained core in ``app/tasmota``.
+
+Deliberately contains no update logic: the CLI resolves the device list and
+orchestrates calls into ``app.tasmota``. Duplicating the update logic is what
+killed the previous CLI (Phase 4 of the 2026-07 audit).
+"""
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+
+EXIT_OK = 0
+EXIT_OUTDATED = 1
+EXIT_ERROR = 2
+
+UNKNOWN_VERSION = "Unknown"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser: three verbs plus shared options."""
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli",
+        description="Check, update or list configured Tasmota devices.",
+    )
+    parser.add_argument("-f", "--file", help="Path to the devices YAML file.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON on stdout.")
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Log level for messages on stderr (default: WARNING).",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("check", help="Compare every device against the latest release.")
+    sub.add_parser("list", help="List configured devices and their firmware (no release lookup).")
+
+    update = sub.add_parser("update", help="Update every outdated device.")
+    update.add_argument(
+        "--timeout",
+        type=int,
+        help="Override the per-device total timeout in seconds.",
+    )
+    update.add_argument(
+        "--force",
+        action="store_true",
+        help="Flash every configured device, including up-to-date ones.",
+    )
+    return parser
+
+
+def resolve_devices_file(explicit: str | None, env: Mapping[str, str]) -> str:
+    """Resolve the devices file the same way ``server.py`` does."""
+    if explicit:
+        return explicit
+    return env.get("DEVICES_FILE", "devices.yaml")

--- a/app/cli.py
+++ b/app/cli.py
@@ -218,8 +218,9 @@ def render_human(
             str(result.get("ip", "?")).ljust(15),
             name.ljust(24),
             _version_column(result).ljust(18),
+            label,
         ]
-        lines.append(("  ".join(columns) + label).rstrip())
+        lines.append("  ".join(columns).rstrip())
     lines.append(_tally_line(command, summary))
     return "\n".join(lines)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -241,10 +241,11 @@ def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for device in devices:
         info = updater.get_device_firmware_version(dict(device))
+        version = info.get("version") if isinstance(info, dict) else None
         result: dict[str, Any] = {
             "ip": device.get("ip"),
-            "success": info is not None,
-            "current_version": (info or {}).get("version", UNKNOWN_VERSION),
+            "success": bool(version),
+            "current_version": version or UNKNOWN_VERSION,
         }
         if device.get("dns_name"):
             result["dns_name"] = device["dns_name"]

--- a/app/cli.py
+++ b/app/cli.py
@@ -211,10 +211,15 @@ def render_human(
         else:
             label = _CHECK_LABELS[classify(result)]
         name = str(result.get("dns_name") or "")
-        line = (
-            f"{str(result.get('ip', '?')):<16}{name:<16}{_version_column(result):<20}{label}"
-        )
-        lines.append(line.rstrip())
+        # Padding alone cannot guarantee a separator: a dns_name or version
+        # longer than its column would run straight into the next one. The
+        # join with a fixed separator keeps columns apart even then.
+        columns = [
+            str(result.get("ip", "?")).ljust(15),
+            name.ljust(24),
+            _version_column(result).ljust(18),
+        ]
+        lines.append(("  ".join(columns) + label).rstrip())
     lines.append(_tally_line(command, summary))
     return "\n".join(lines)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -232,6 +232,44 @@ def render_json(
     return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
 
 
+class CliError(Exception):
+    """A condition that must end the run with EXIT_ERROR."""
+
+
+def run_batch(
+    devices: Sequence[Mapping[str, Any]],
+    *,
+    check_only: bool,
+    timeout: int | None,
+) -> list[dict[str, Any]]:
+    """Run the shared batch runner synchronously and return its results.
+
+    ``update_only_needed`` is always False: the CLI decides itself which
+    devices to touch, because the runner's internal filter drops skipped
+    devices from the results and would hide a failed comparison.
+    """
+    job_id = jobs.create_batch_job(
+        [dict(device) for device in devices],
+        check_only=check_only,
+        update_only_needed=False,
+        global_timeout=timeout,
+        background=False,
+    )
+    if job_id is None:
+        raise CliError("Could not create a batch job — another one is already running.")
+    job = jobs.get_job(job_id)
+    if job is None:
+        raise CliError(f"Batch job {job_id} disappeared before it could be read.")
+    if job.get("status") == "error":
+        raise CliError(str(job.get("error") or "The batch runner failed."))
+    return [dict(result) for result in job.get("results", [])]
+
+
+def cmd_check(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Compare every configured device against the latest release."""
+    return run_batch(devices, check_only=True, timeout=None)
+
+
 def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     """Inventory: what is configured and what firmware runs on it.
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -18,24 +18,38 @@ UNKNOWN_VERSION = "Unknown"
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser: three verbs plus shared options."""
-    parser = argparse.ArgumentParser(
-        prog="python -m app.cli",
-        description="Check, update or list configured Tasmota devices.",
-    )
-    parser.add_argument("-f", "--file", help="Path to the devices YAML file.")
-    parser.add_argument("--json", action="store_true", help="Emit JSON on stdout.")
-    parser.add_argument(
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("-f", "--file", help="Path to the devices YAML file.")
+    common.add_argument("--json", action="store_true", help="Emit JSON on stdout.")
+    common.add_argument(
         "--log-level",
         default="WARNING",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         help="Log level for messages on stderr (default: WARNING).",
     )
 
-    sub = parser.add_subparsers(dest="command", required=True)
-    sub.add_parser("check", help="Compare every device against the latest release.")
-    sub.add_parser("list", help="List configured devices and their firmware (no release lookup).")
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli",
+        description="Check, update or list configured Tasmota devices.",
+    )
 
-    update = sub.add_parser("update", help="Update every outdated device.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser(
+        "check",
+        parents=[common],
+        help="Compare every device against the latest release.",
+    )
+    sub.add_parser(
+        "list",
+        parents=[common],
+        help="List configured devices and their firmware (no release lookup).",
+    )
+
+    update = sub.add_parser(
+        "update",
+        parents=[common],
+        help="Update every outdated device.",
+    )
     update.add_argument(
         "--timeout",
         type=int,

--- a/app/cli.py
+++ b/app/cli.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
+import os
+import sys
+from collections import Counter
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 from app.tasmota import jobs, updater, utils
@@ -332,3 +337,88 @@ def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
             result["dns_name"] = device["dns_name"]
         results.append(result)
     return results
+
+
+def _duplicate_ips(devices: Sequence[Mapping[str, Any]]) -> list[Any]:
+    """Return IPs that appear more than once, in first-seen order.
+
+    Two entries sharing an IP would silently collapse inside ``cmd_update``'s
+    IP-to-config mapping: one config gets flashed twice with the wrong
+    credentials while the other is never touched.
+    """
+    counts = Counter(device.get("ip") for device in devices)
+    return [ip for ip, count in counts.items() if count > 1]
+
+
+def _configure_logging(level: str) -> None:
+    """All logging goes to stderr so stdout stays parseable with --json."""
+    logging.basicConfig(
+        level=getattr(logging, level),
+        stream=sys.stderr,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _load_env() -> None:
+    """Honour ENV_FILE like server.py does, so ENV_FILE=.env.dev works."""
+    env_file = Path(os.environ.get("ENV_FILE", ".env"))
+    if env_file.exists():
+        from dotenv import load_dotenv
+
+        load_dotenv(str(env_file))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns the exit code, never raises for expected failures."""
+    args = build_parser().parse_args(argv)
+    _configure_logging(args.log_level)
+    _load_env()
+
+    devices_file = resolve_devices_file(args.file, os.environ)
+    if not Path(devices_file).exists():
+        print(f"Devices file not found: {devices_file}", file=sys.stderr)
+        return EXIT_ERROR
+
+    devices = utils.load_devices_from_file(devices_file)
+    if not devices:
+        print(f"No devices configured in {devices_file}", file=sys.stderr)
+        return EXIT_ERROR
+
+    duplicates = _duplicate_ips(devices)
+    if duplicates:
+        print(
+            "Duplicate IP(s) in "
+            f"{devices_file}: {', '.join(str(ip) for ip in duplicates)}",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    try:
+        if args.command == "list":
+            results = cmd_list(devices)
+        elif args.command == "check":
+            results = cmd_check(devices)
+        else:
+            results = cmd_update(devices, force=args.force, timeout=args.timeout)
+    except CliError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_ERROR
+    except KeyboardInterrupt:
+        print(
+            "Abgebrochen. Achtung: ein bereits gestarteter OTA-Flash läuft auf dem "
+            "Gerät weiter und wurde nicht zurückgenommen.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    summary = summarize(results, args.command)
+    code = exit_code_for(args.command, summary)
+    if args.json:
+        print(render_json(args.command, devices_file, results, summary, code))
+    else:
+        print(render_human(args.command, results, summary))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/audit-2026-07/2026-07-28-cli-design.md
+++ b/docs/audit-2026-07/2026-07-28-cli-design.md
@@ -51,7 +51,7 @@ Entry-Point ohne Installation nicht existiert.
 
 ```
 python -m app.cli [-f PATH] [--json] [--log-level LEVEL] {check|update|list}
-python -m app.cli update [--timeout SECONDS] [--force]
+python -m app.cli update [--timeout SECONDS]
 ```
 
 | Option | Bedeutung |
@@ -60,17 +60,20 @@ python -m app.cli update [--timeout SECONDS] [--force]
 | `--json` | Ergebnis als JSON auf stdout statt Tabelle. |
 | `--log-level LEVEL` | Default `WARNING`, damit eine cron-Mail bei Erfolg schlank bleibt. |
 | `--timeout SECONDS` | nur `update`: überschreibt den Gesamt-Timeout pro Gerät. |
-| `--force` | nur `update`: flasht **alle** konfigurierten Geräte, auch aktuelle. |
 
-Ohne `--force` fasst `update` nur veraltete Geräte an — die sichere
-Voreinstellung für einen unbeaufsichtigten Lauf.
+`update` fasst nur veraltete Geräte an — die sichere Voreinstellung für einen
+unbeaufsichtigten Lauf. Ein erneutes Flashen eines Geräts, das bereits die
+aktuelle Version meldet, wird nicht unterstützt: der Kern überspringt es
+(`update_device_firmware()` meldet Erfolg, ohne das Gerät anzufassen). Ein
+Gerät, das seine eigene Version falsch meldet, lässt sich über die CLI
+derzeit deshalb nicht zurückholen.
 
 ## Delegation an den Kern
 
 | Verb | Aufruf |
 |---|---|
 | `check` | `jobs.create_batch_job(devices, check_only=True, update_only_needed=False, global_timeout=None, background=False)` |
-| `update` | `jobs.create_batch_job(devices, check_only=False, update_only_needed=not force, global_timeout=timeout, background=False)` |
+| `update` | `jobs.create_batch_job(devices, check_only=False, update_only_needed=False, global_timeout=timeout, background=False)` — die CLI wählt die Teilmenge selbst aus (siehe Zwei-Pass-Ablauf unten), statt dem Runner-eigenen Filter zu vertrauen |
 | `list` | `updater.get_device_firmware_version(device)` je Gerät, **ohne** `fetch_latest_tasmota_release()` |
 
 Geräte kommen aus `utils.load_devices_from_file()`.
@@ -208,9 +211,8 @@ Bei gemischten Ergebnissen gewinnt der höhere Code: Fehler (2) schlägt
 veraltet (1) schlägt in Ordnung (0). Exit 1 tritt nur bei `check` auf.
 
 Bei `update` heißt Exit 2 also nicht zwingend, dass ein Flash-Versuch
-scheiterte: `update` klassifiziert zuerst alle Geräte und flasht nur die
-ausgewählten (veraltete, oder mit `--force` alle erreichbaren/vergleichbaren).
-Ein nicht erreichbares oder nicht vergleichbares Gerät wird nie geflasht, zählt
+scheiterte: `update` klassifiziert zuerst alle Geräte und flasht nur die als
+veraltet erkannten. Ein nicht erreichbares oder nicht vergleichbares Gerät wird nie geflasht, zählt
 aber trotzdem in `failed`/`comparison_unknown` und hebt den Exit-Code
 weiterhin auf 2 — derselbe Effekt wie bei `check`, nur leichter
 missverständlich, weil man bei `update` zuerst an einen fehlgeschlagenen
@@ -244,7 +246,7 @@ ein cron-Job dann dauerhaft schweigt. Ein unbekannter Vergleich ist ein Fehler
 
 Unit-Tests über den Wrapper mit gemocktem Kern:
 
-- Argument-Parsing je Verb, inklusive der Ablehnung von `--timeout`/`--force`
+- Argument-Parsing je Verb, inklusive der Ablehnung von `--timeout`
   bei `check` und `list`.
 - Die vollständige Exit-Code-Matrix, ausdrücklich mit dem Unknown-Fall und der
   Präzedenz bei gemischten Ergebnissen.

--- a/docs/audit-2026-07/2026-07-28-cli-design.md
+++ b/docs/audit-2026-07/2026-07-28-cli-design.md
@@ -1,0 +1,255 @@
+# Design: dünne CLI-Schicht über `app/tasmota`
+
+Stand 2026-07-28. Umsetzung des Backlog-Eintrags unter Phase 4 in
+[`implementation-plan.md`](implementation-plan.md).
+
+## Ziel und Abgrenzung
+
+Eine CLI für Automatisierung (cron, Skripte), die **keine** Update-Logik
+enthält, sondern den gepflegten Kern in `app/tasmota` aufruft. Der
+Deprecation-Grund der alten CLI war die Duplikation von ~900 Zeilen
+Update-Logik, nicht der Nutzen einer CLI. Diese Schicht darf deshalb keinen
+zweiten Ausführungspfad einführen.
+
+Nicht Ziel: Einzelgeräte-Bedienung per IP, interaktive Konfiguration,
+Parallelität, ein Ersatz für die Web-UI.
+
+## Einsatzzwecke
+
+1. **Nächtlicher Check ohne Update** — melden, wenn Geräte veraltet sind.
+2. **Unbeaufsichtigtes Update** — alles Veraltete aktualisieren, Bilanz ausgeben.
+3. **Inventar** — Datenquelle für Monitoring/Skripte.
+
+## Aufruf
+
+Primär als Modul, ohne jede Installation:
+
+```bash
+python -m app.cli check
+python -m app.cli update --timeout 300
+python -m app.cli list --json
+```
+
+Im Container ohne neue Build-Schicht:
+
+```bash
+podman run --rm -v ./devices.yaml:/app/devices.yaml:ro \
+  --entrypoint python dodjango/tasmota-updater -m app.cli check
+```
+
+`app/__init__.py` enthält nur `__version__` und importiert kein Flask, der
+Modulaufruf zieht also keinen Server-Ballast nach.
+
+Zusätzlich wird ein `[project.scripts]`-Eintrag
+(`tasmota-updater = "app.cli:main"`) in `pyproject.toml` angelegt. Er kostet drei
+Zeilen und liefert den kurzen Befehl für jeden, der das Paket installiert — die
+Doku verspricht ihn aber **nicht** als Standardweg, weil das Projekt derzeit
+nirgends installiert wird (weder lokal noch im Containerfile) und ein
+Entry-Point ohne Installation nicht existiert.
+
+## Befehlsfläche
+
+```
+python -m app.cli [-f PATH] [--json] [--log-level LEVEL] {check|update|list}
+python -m app.cli update [--timeout SECONDS] [--force]
+```
+
+| Option | Bedeutung |
+|---|---|
+| `-f`, `--file PATH` | Gerätedatei. Auflösung wie im Server: `-f` schlägt `DEVICES_FILE` aus Umgebung/`.env`, sonst `devices.yaml`. |
+| `--json` | Ergebnis als JSON auf stdout statt Tabelle. |
+| `--log-level LEVEL` | Default `WARNING`, damit eine cron-Mail bei Erfolg schlank bleibt. |
+| `--timeout SECONDS` | nur `update`: überschreibt den Gesamt-Timeout pro Gerät. |
+| `--force` | nur `update`: flasht **alle** konfigurierten Geräte, auch aktuelle. |
+
+Ohne `--force` fasst `update` nur veraltete Geräte an — die sichere
+Voreinstellung für einen unbeaufsichtigten Lauf.
+
+## Delegation an den Kern
+
+| Verb | Aufruf |
+|---|---|
+| `check` | `jobs.create_batch_job(devices, check_only=True, update_only_needed=False, global_timeout=None, background=False)` |
+| `update` | `jobs.create_batch_job(devices, check_only=False, update_only_needed=not force, global_timeout=timeout, background=False)` |
+| `list` | `updater.get_device_firmware_version(device)` je Gerät, **ohne** `fetch_latest_tasmota_release()` |
+
+Geräte kommen aus `utils.load_devices_from_file()`.
+
+Den Batch-Runner zu verwenden statt selbst zu schleifen ist der Kern des
+Entwurfs: er *ist* die sequenzielle Abarbeitung inklusive `update_only_needed`
+und Ergebniszählung, und `background=False` existiert bereits für die Tests.
+Sequenziell bleibt es bewusst — bei OTA hängt jedes Gerät minutenlang im
+Flash-Fenster, und mehrere gleichzeitig rebootende Geräte im selben WLAN sind
+eine unnötige Störquelle.
+
+Zwei Eigenheiten des Runners, die die CLI berücksichtigen muss:
+
+- `create_batch_job()` liefert `None`, wenn bereits ein Job läuft. Im frischen
+  CLI-Prozess unmöglich, wird aber als interner Fehler mit Exit 2 behandelt
+  statt ignoriert.
+- Bei `update_only_needed=True` ruft der Runner zum Filtern für jedes Gerät
+  zusätzlich `check_only=True` auf. Ein Update-Lauf prüft betroffene Geräte
+  also zweimal. Akzeptiert: es ist ein HTTP-Aufruf ins LAN, und der Filter ist
+  getesteter Bestandteil des Runners.
+
+`list` benutzt den Runner nicht, weil es den Release-Lookup gerade *nicht*
+braucht — es ist der einzige Pfad ohne GitHub-Abhängigkeit und damit ohne
+Rate-Limit-Risiko.
+
+## Ausgabe
+
+stdout trägt ausschließlich das Ergebnis, stderr Logs und Fehler. Damit bleibt
+`--json` unter allen Log-Leveln parsebar.
+
+Menschenlesbar (Default), eine Zeile pro Gerät plus Bilanz:
+
+```
+192.168.8.191  tasmota-flur    14.6.0 → 15.0.1   Update verfügbar
+192.168.8.192  tasmota-kueche  15.0.1            aktuell
+192.168.8.193  tasmota-bad     15.0.1            Vergleich unbekannt
+192.168.8.194  tasmota-keller  —                 nicht erreichbar
+1 aktuell, 1 Update verfügbar, 1 Vergleich unbekannt, 1 Fehler
+```
+
+Mit `--json` ein Objekt, das die Ergebnis-Dicts des Kerns unverändert
+durchreicht:
+
+```json
+{
+  "command": "check",
+  "devices_file": "devices.yaml",
+  "results": [
+    {
+      "ip": "192.168.8.191",
+      "success": true,
+      "current_version": "14.6.0",
+      "latest_version": "15.0.1",
+      "needs_update": true,
+      "message": "..."
+    }
+  ],
+  "summary": {
+    "total": 4,
+    "up_to_date": 1,
+    "needs_update": 1,
+    "comparison_unknown": 1,
+    "failed": 1
+  },
+  "exit_code": 2
+}
+```
+
+`results` ist gekürzt; die Bilanz beschreibt alle vier Geräte des Beispiels
+oben. Der `exit_code` ist hier **2** und nicht 1, weil ein Fehler und ein
+unbekannter Vergleich das „veraltet" überstimmen.
+
+Bei `list` fehlen in den Ergebnissen die Vergleichsfelder (`latest_version`,
+`needs_update`) und in der Bilanz entsprechend `up_to_date`, `needs_update` und
+`comparison_unknown` — dort gibt es nur `total` und `failed`, weil kein
+Release-Lookup stattfindet.
+
+Die CLI berechnet `summary` **selbst** aus `results`. Die Summary des
+Job-Runners (`total`, `processed`, `success`, `needs_update`, `updated`) kann
+den Zustand „Vergleich unbekannt" nicht ausdrücken, und `success` unterscheidet
+nicht zwischen „aktuell" und „nicht vergleichbar". Die Zuordnung:
+
+| Bilanz-Feld | Bedingung im Ergebnis-Dict |
+|---|---|
+| `failed` | `success` falsch |
+| `comparison_unknown` | `success` wahr, aber `latest_version` fehlt oder ist `"Unknown"` |
+| `needs_update` | `needs_update` wahr |
+| `up_to_date` | `success` wahr, `latest_version` bekannt, `needs_update` falsch |
+
+## Exit-Codes
+
+| | `check` | `update` | `list` |
+|---|---|---|---|
+| **0** | alles aktuell | nichts zu tun oder alle Updates erfolgreich | alle Geräte erreichbar |
+| **1** | mindestens eines veraltet | — | — |
+| **2** | Fehler | mindestens ein Update fehlgeschlagen | mindestens eines unerreichbar |
+
+Bei gemischten Ergebnissen gewinnt der höhere Code: Fehler (2) schlägt
+veraltet (1) schlägt in Ordnung (0). Exit 1 tritt nur bei `check` auf.
+
+Damit reicht für cron ein Einzeiler, ohne `jq`:
+
+```bash
+python -m app.cli check || mail -s "Tasmota veraltet" me@example.com
+```
+
+**Die wichtigste Regel des Entwurfs:** `needs_update: false` bedeutet auch
+„konnte nicht vergleichen" (gescheiterter Release-Lookup →
+`latest_version: "Unknown"`). Das darf **nie** als „alles aktuell, Exit 0"
+erscheinen — es wäre der Zwilling des UI-Bugs aus #91, nur folgenschwerer, weil
+ein cron-Job dann dauerhaft schweigt. Ein unbekannter Vergleich ist ein Fehler
+(Exit 2) und heißt in der Ausgabe `Vergleich unbekannt`.
+
+## Fehlerbehandlung
+
+| Fall | Verhalten |
+|---|---|
+| Gerätedatei fehlt oder ist ungültiges YAML | Meldung auf stderr, Exit 2, kein Gerät angefasst |
+| Leere Geräteliste | Meldung auf stderr, Exit 2 (eine leere Konfiguration ist kein Erfolg) |
+| Gerät unerreichbar | Zeile im Ergebnis, Lauf geht weiter, am Ende Exit 2 |
+| Release-Lookup gescheitert | `Vergleich unbekannt`, Exit 2 |
+| `create_batch_job()` liefert `None` | Meldung auf stderr, Exit 2 |
+| `Ctrl-C` während eines Updates | `KeyboardInterrupt` wird gefangen, Warnung auf stderr, Exit 2 — mit dem ausdrücklichen Hinweis, dass ein laufender OTA-Flash auf dem Gerät weiterläuft und nicht abgebrochen wurde |
+
+## Tests
+
+Unit-Tests über den Wrapper mit gemocktem Kern:
+
+- Argument-Parsing je Verb, inklusive der Ablehnung von `--timeout`/`--force`
+  bei `check` und `list`.
+- Die vollständige Exit-Code-Matrix, ausdrücklich mit dem Unknown-Fall und der
+  Präzedenz bei gemischten Ergebnissen.
+- Bilanz-Zuordnung aus `results` (die vier Felder oben).
+- Bei `--json` liegt auf stdout ausschließlich JSON, auch mit
+  `--log-level DEBUG`.
+
+Dazu ein Smoke-Test im Subprozess gegen `devices-dev.yaml` (Fake-Geräte), wie
+es die e2e-Suite mit dem Server macht: `list --json` und `check --json`. Beim
+`check` wird der Release-Lookup gestubbt — der Live-Aufruf macht CI flaky, das
+ist die Lehre aus #76. Keine neuen pytest-Marker; die Tests laufen im grünen
+Kern.
+
+## Doku-Abgleich
+
+Gehört in denselben PR, sonst driftet es wie zuvor:
+
+- `docs/cli-usage.md` neu schreiben: Deprecation-Banner raus, die alten
+  Optionen (`--update-all`, `--example`, Wizard) ausdrücklich als entfallen
+  benennen.
+- `README.md`: „Two supported interfaces" → drei; der Absatz, der die CLI für
+  tot erklärt, muss weg.
+- `CLAUDE.md`: „There is **no working CLI**" korrigieren.
+- `tasmota_updater.py`: bleibt Stub, verweist künftig auf `python -m app.cli`.
+- `implementation-plan.md`: Backlog-Eintrag als erledigt markieren, mit den
+  Abweichungen.
+
+PR-Titel `feat(cli): …` — das ergibt bewusst einen Minor-Bump.
+
+## Entscheidungen und Verworfenes
+
+| Verworfen | Grund |
+|---|---|
+| `--dry-run` | Doppelt zum Verb `check`. |
+| `--non-interactive`, Konfigurations-Wizard | Die CLI ist immer nicht-interaktiv; ein `update` fasst Geräte an, das ist der Zweck des Aufrufs. |
+| Bestätigungsabfrage vor `update` | Ebenso — würde den cron-Einsatz gerade verhindern. |
+| Einzelgeräte-Verb (`update <ip>`) | Kein Bedarf; die Web-UI deckt Ad-hoc-Eingriffe ab. |
+| Begrenzte Parallelität | Wenige Geräte, und rebootende Geräte im selben WLAN sind eine Störquelle. |
+| `tasmota_updater.py` wiederbeleben | Die alte, kaputte CLI soll nicht zurückkehren; der Stub bleibt Wegweiser. |
+| Installation (`pip install .`) zur Voraussetzung machen | Würde Container-Build und Setup-Anleitung für ein Feature ändern, das sonst nichts davon braucht. |
+| Flags statt Verben (`--check-only`, `--update-all`) | Drei Verben sind klarer; die alte Syntax ist ohnehin nicht kompatibel. |
+
+`list` bleibt trotz Überlappung mit `check --json` erhalten: es braucht keinen
+GitHub-Aufruf und liefert nie Exit 1.
+
+## Restrisiken
+
+- Dass `update` gegen echte Hardware trägt, zeigt erst ein Lauf am Gerät —
+  Fake-Geräte reproduzieren das OTA-Flash-Fenster nicht (dieselbe Einschränkung
+  wie bei #87).
+- Der Timeout-Default kommt aus der Gerätekonfiguration. Ein zu knapper Wert
+  äußert sich als Fehlschlag, obwohl der Flash im Hintergrund noch läuft; das
+  ist Verhalten des Kerns, nicht der CLI.

--- a/docs/audit-2026-07/2026-07-28-cli-design.md
+++ b/docs/audit-2026-07/2026-07-28-cli-design.md
@@ -112,36 +112,72 @@ Menschenlesbar (Default), eine Zeile pro Gerät plus Bilanz:
 ```
 
 Mit `--json` ein Objekt, das die Ergebnis-Dicts des Kerns unverändert
-durchreicht:
+durchreicht — `json.dumps(..., sort_keys=True)`, die Schlüssel sind also
+alphabetisch sortiert, und jedes Ergebnis trägt alle Felder, die der Kern
+liefert (nicht nur die für den Vergleich relevanten). Echter, unveränderter
+Lauf gegen zwei Geräte (eines per Fake-Firmware, eines mit ungültiger IP, um
+einen echten Fehlerfall zu zeigen):
 
 ```json
 {
   "command": "check",
-  "devices_file": "devices.yaml",
+  "devices_file": "devices-doc-example.yaml",
+  "exit_code": 2,
   "results": [
     {
-      "ip": "192.168.8.191",
-      "success": true,
-      "current_version": "14.6.0",
-      "latest_version": "15.0.1",
+      "current_version": "12.0.2",
+      "dns_name": "fake-tasmota-light1.local",
+      "ip": "192.168.100.101",
+      "latest_version": "15.5.0",
+      "message": "Update available",
       "needs_update": true,
-      "message": "..."
+      "success": true,
+      "timeout_config": {
+        "initial_wait": 10,
+        "max_check_interval": 30.0,
+        "min_check_interval": 2.0,
+        "total_timeout": 240
+      },
+      "timeout_report": null,
+      "update_completed": false,
+      "update_started": false,
+      "version_verification": null
+    },
+    {
+      "current_version": "Unknown",
+      "dns_name": "localhost",
+      "ip": "127.0.0.1",
+      "latest_version": "Unknown",
+      "message": "Failed to get current firmware version",
+      "needs_update": false,
+      "success": false,
+      "timeout_config": {
+        "initial_wait": 10,
+        "max_check_interval": 30.0,
+        "min_check_interval": 2.0,
+        "total_timeout": 240
+      },
+      "timeout_report": null,
+      "update_completed": false,
+      "update_started": false,
+      "version_verification": null
     }
   ],
   "summary": {
-    "total": 4,
-    "up_to_date": 1,
+    "comparison_unknown": 0,
+    "failed": 1,
     "needs_update": 1,
-    "comparison_unknown": 1,
-    "failed": 1
-  },
-  "exit_code": 2
+    "total": 2,
+    "up_to_date": 0
+  }
 }
 ```
 
-`results` ist gekürzt; die Bilanz beschreibt alle vier Geräte des Beispiels
-oben. Der `exit_code` ist hier **2** und nicht 1, weil ein Fehler und ein
-unbekannter Vergleich das „veraltet" überstimmen.
+Der `exit_code` ist hier **2** und nicht 1, weil ein Fehler das „veraltet"
+überstimmt — genau die Präzedenz, die unten im Abschnitt Exit-Codes
+beschrieben ist. `comparison_unknown` steht in diesem Lauf auf 0, weil der
+Release-Lookup erfolgreich war; die Zuordnung, wann dieses Feld greift, steht
+in der Tabelle unten.
 
 Bei `list` fehlen in den Ergebnissen die Vergleichsfelder (`latest_version`,
 `needs_update`) und in der Bilanz entsprechend `up_to_date`, `needs_update` und
@@ -166,10 +202,19 @@ nicht zwischen „aktuell" und „nicht vergleichbar". Die Zuordnung:
 |---|---|---|---|
 | **0** | alles aktuell | nichts zu tun oder alle Updates erfolgreich | alle Geräte erreichbar |
 | **1** | mindestens eines veraltet | — | — |
-| **2** | Fehler | mindestens ein Update fehlgeschlagen | mindestens eines unerreichbar |
+| **2** | Fehler | ein Flash fehlgeschlagen, oder ein Gerät war unerreichbar/nicht vergleichbar — auch eines, das `update` gar nicht angefasst hat | mindestens eines unerreichbar |
 
 Bei gemischten Ergebnissen gewinnt der höhere Code: Fehler (2) schlägt
 veraltet (1) schlägt in Ordnung (0). Exit 1 tritt nur bei `check` auf.
+
+Bei `update` heißt Exit 2 also nicht zwingend, dass ein Flash-Versuch
+scheiterte: `update` klassifiziert zuerst alle Geräte und flasht nur die
+ausgewählten (veraltete, oder mit `--force` alle erreichbaren/vergleichbaren).
+Ein nicht erreichbares oder nicht vergleichbares Gerät wird nie geflasht, zählt
+aber trotzdem in `failed`/`comparison_unknown` und hebt den Exit-Code
+weiterhin auf 2 — derselbe Effekt wie bei `check`, nur leichter
+missverständlich, weil man bei `update` zuerst an einen fehlgeschlagenen
+Flash denkt.
 
 Damit reicht für cron ein Einzeiler, ohne `jq`:
 

--- a/docs/audit-2026-07/2026-07-28-cli-plan.md
+++ b/docs/audit-2026-07/2026-07-28-cli-plan.md
@@ -1,0 +1,1439 @@
+# Thin CLI Wrapper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `python -m app.cli` with three verbs (`check`, `update`, `list`) over the maintained core in `app/tasmota`, with cron-usable exit codes and no duplicated update logic.
+
+**Architecture:** A single module `app/cli.py`. Pure helpers (classification, tally, exit code, rendering) are separated from the three verb functions so the exit-code matrix is testable without touching the network. Device work is delegated: `utils.load_devices_from_file()`, `jobs.create_batch_job(..., background=False)` for check/update, `updater.get_device_firmware_version()` for `list`.
+
+**Tech Stack:** Python 3.10+, argparse, stdlib `json`/`logging`, pytest. No new runtime dependencies.
+
+## Global Constraints
+
+- Design document: [`2026-07-28-cli-design.md`](2026-07-28-cli-design.md). Read it before starting.
+- Exit codes: `0` ok, `1` outdated (only `check`), `2` error. Higher code wins on mixed results.
+- A failed release lookup (`latest_version` missing or `"Unknown"`) is an **error** (exit 2) and renders as `Vergleich unbekannt` — never as `aktuell`. This is the #91 trap.
+- An empty device list is exit 2, not success.
+- stdout carries only the result (table or JSON); logs and errors go to stderr. With `--json`, stdout must be parseable at any log level.
+- Devices are processed sequentially. No parallelism.
+- No `--dry-run`, no `--non-interactive`, no interactive prompts, no single-device verb.
+- Style rules from `pyproject.toml` apply: line length 100, ruff (`PTH` — use `pathlib`, not `os.path`), mypy with `disallow_untyped_defs = true`, so **every** function needs annotations.
+- Never write update logic in `app/cli.py`. Only orchestration of existing core functions.
+
+## Two refinements over the design document
+
+Both were found while writing this plan. They tighten the design, they do not
+contradict its goals — but they differ from its wording, so they are called out
+here rather than buried in a task.
+
+**1. `update` runs two passes instead of one.** The design delegates to a single
+`create_batch_job(..., update_only_needed=not force)`. That cannot work
+honestly: with `update_only_needed=True` the runner filters devices internally
+and returns results **only for the devices it processed**. Devices skipped
+because their comparison failed vanish from `results` entirely, so a broken
+release lookup would look exactly like "everything current" — the very trap the
+design forbids. Instead:
+
+1. Pass one: `create_batch_job(devices, check_only=True, update_only_needed=False, …)` — classify every device.
+2. Pass two: `create_batch_job(subset, check_only=False, update_only_needed=False, …)` where `subset` is the devices classified `needs_update` (with `--force`: every successfully reached device).
+3. Merge pass-two results with the pass-one results of the untouched devices.
+
+Side effect: this also removes the double-check noted in the design, because
+pass two is called with `update_only_needed=False` and does not filter again.
+
+**2. Per-command tally shapes.** One tally shape cannot serve all three verbs: a
+device that was just updated still carries `needs_update: true` from its
+pre-update comparison, so labelling it "Update verfügbar" would be wrong.
+
+| Command | Tally keys |
+|---|---|
+| `list` | `total`, `failed` |
+| `check` | `total`, `up_to_date`, `needs_update`, `comparison_unknown`, `failed` |
+| `update` | `total`, `updated`, `skipped`, `comparison_unknown`, `failed` |
+
+`exit_code_for()` reads only `failed`, `comparison_unknown` and `needs_update`,
+so it works unchanged for all three.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| Create `app/cli.py` | The whole CLI: parser, pure helpers, three verbs, `main()`. Expected ~220 lines. |
+| Create `tests/test_cli.py` | Unit tests with a mocked core. |
+| Create `tests/test_cli_smoke.py` | Subprocess smoke test against the fake devices. |
+| Modify `pyproject.toml` | `[project.scripts]` entry point. |
+| Modify `tasmota_updater.py` | Stub text points at `python -m app.cli`. Keeps exiting 1. Its wording loses the word "deprecated", so `tests/test_cli_deprecated.py` must be adjusted in the same commit — see Task 10, Step 1. |
+| Modify `tests/test_cli_deprecated.py` | Assert the stub names the new command instead of asserting the word "deprecated". |
+| Modify `docs/cli-usage.md`, `README.md`, `CLAUDE.md`, `docs/audit-2026-07/implementation-plan.md` | Documentation reconciliation. |
+
+---
+
+### Task 1: Parser and devices-file resolution
+
+**Files:**
+- Create: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `EXIT_OK: int`, `EXIT_OUTDATED: int`, `EXIT_ERROR: int`, `build_parser() -> argparse.ArgumentParser`, `resolve_devices_file(explicit: str | None, env: Mapping[str, str]) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli.py
+"""Unit tests for the thin CLI wrapper (app/cli.py)."""
+import pytest
+
+from app import cli
+
+
+def test_parser_requires_a_command():
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+@pytest.mark.parametrize("command", ["check", "update", "list"])
+def test_parser_accepts_each_command(command):
+    args = cli.build_parser().parse_args([command])
+    assert args.command == command
+    assert args.file is None
+    assert args.json is False
+    assert args.log_level == "WARNING"
+
+
+def test_parser_accepts_update_options():
+    args = cli.build_parser().parse_args(["update", "--timeout", "300", "--force"])
+    assert args.timeout == 300
+    assert args.force is True
+
+
+@pytest.mark.parametrize("command", ["check", "list"])
+def test_parser_rejects_update_options_on_other_commands(command):
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args([command, "--force"])
+
+
+def test_resolve_devices_file_prefers_explicit_path():
+    assert cli.resolve_devices_file("custom.yaml", {"DEVICES_FILE": "env.yaml"}) == "custom.yaml"
+
+
+def test_resolve_devices_file_falls_back_to_environment():
+    assert cli.resolve_devices_file(None, {"DEVICES_FILE": "env.yaml"}) == "env.yaml"
+
+
+def test_resolve_devices_file_defaults_to_devices_yaml():
+    assert cli.resolve_devices_file(None, {}) == "devices.yaml"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.cli'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/cli.py
+"""Thin command-line wrapper over the maintained core in ``app/tasmota``.
+
+Deliberately contains no update logic: the CLI resolves the device list and
+orchestrates calls into ``app.tasmota``. Duplicating the update logic is what
+killed the previous CLI (Phase 4 of the 2026-07 audit).
+"""
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+
+EXIT_OK = 0
+EXIT_OUTDATED = 1
+EXIT_ERROR = 2
+
+UNKNOWN_VERSION = "Unknown"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser: three verbs plus shared options."""
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli",
+        description="Check, update or list configured Tasmota devices.",
+    )
+    parser.add_argument("-f", "--file", help="Path to the devices YAML file.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON on stdout.")
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Log level for messages on stderr (default: WARNING).",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("check", help="Compare every device against the latest release.")
+    sub.add_parser("list", help="List configured devices and their firmware (no release lookup).")
+
+    update = sub.add_parser("update", help="Update every outdated device.")
+    update.add_argument(
+        "--timeout",
+        type=int,
+        help="Override the per-device total timeout in seconds.",
+    )
+    update.add_argument(
+        "--force",
+        action="store_true",
+        help="Flash every configured device, including up-to-date ones.",
+    )
+    return parser
+
+
+def resolve_devices_file(explicit: str | None, env: Mapping[str, str]) -> str:
+    """Resolve the devices file the same way ``server.py`` does."""
+    if explicit:
+        return explicit
+    return env.get("DEVICES_FILE", "devices.yaml")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): add argument parser and devices-file resolution"
+```
+
+---
+
+### Task 2: Result classification and per-command tally
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `UNKNOWN_VERSION` from Task 1.
+- Produces: `classify(result: Mapping[str, Any]) -> str` returning one of `"failed"`, `"comparison_unknown"`, `"needs_update"`, `"up_to_date"`; `summarize(results: Sequence[Mapping[str, Any]], command: str) -> dict[str, int]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def _result(**overrides):
+    base = {
+        "ip": "192.168.8.191",
+        "success": True,
+        "current_version": "14.6.0",
+        "latest_version": "15.0.1",
+        "needs_update": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_classify_failed_device():
+    assert cli.classify(_result(success=False)) == "failed"
+
+
+@pytest.mark.parametrize("latest", ["Unknown", "", None])
+def test_classify_unknown_comparison(latest):
+    assert cli.classify(_result(latest_version=latest)) == "comparison_unknown"
+
+
+def test_classify_missing_latest_version_is_unknown():
+    result = _result()
+    del result["latest_version"]
+    assert cli.classify(result) == "comparison_unknown"
+
+
+def test_classify_needs_update():
+    assert cli.classify(_result(needs_update=True)) == "needs_update"
+
+
+def test_classify_up_to_date():
+    assert cli.classify(_result()) == "up_to_date"
+
+
+def test_classify_failure_wins_over_unknown():
+    assert cli.classify(_result(success=False, latest_version="Unknown")) == "failed"
+
+
+def test_summarize_check_counts_every_class():
+    results = [
+        _result(ip="1", needs_update=True),
+        _result(ip="2"),
+        _result(ip="3", latest_version="Unknown"),
+        _result(ip="4", success=False),
+    ]
+    assert cli.summarize(results, "check") == {
+        "total": 4,
+        "up_to_date": 1,
+        "needs_update": 1,
+        "comparison_unknown": 1,
+        "failed": 1,
+    }
+
+
+def test_summarize_list_only_counts_failures():
+    results = [_result(ip="1"), _result(ip="2", success=False)]
+    assert cli.summarize(results, "list") == {"total": 2, "failed": 1}
+
+
+def test_summarize_update_counts_updated_and_skipped():
+    results = [
+        _result(ip="1", needs_update=True, update_completed=True),
+        _result(ip="2"),
+        _result(ip="3", success=False, update_started=True),
+        _result(ip="4", latest_version="Unknown"),
+    ]
+    assert cli.summarize(results, "update") == {
+        "total": 4,
+        "updated": 1,
+        "skipped": 1,
+        "comparison_unknown": 1,
+        "failed": 1,
+    }
+
+
+def test_summarize_update_does_not_count_an_updated_device_as_skipped():
+    """After a successful update the device reports the new version, so it
+    classifies as up_to_date — it must not land in both buckets."""
+    results = [_result(ip="1", needs_update=False, update_completed=True)]
+    assert cli.summarize(results, "update") == {
+        "total": 1,
+        "updated": 1,
+        "skipped": 0,
+        "comparison_unknown": 0,
+        "failed": 0,
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'classify'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the imports `from collections.abc import Mapping, Sequence` and `from typing import Any` at the top of `app/cli.py`, then append:
+
+```python
+def classify(result: Mapping[str, Any]) -> str:
+    """Classify one core result dict. The four classes are mutually exclusive.
+
+    ``needs_update: False`` also means "could not compare" when the release
+    lookup failed, so an unknown ``latest_version`` must be recognised before
+    anything is called up to date (#91).
+    """
+    if not result.get("success"):
+        return "failed"
+    latest = result.get("latest_version")
+    if not latest or latest == UNKNOWN_VERSION:
+        return "comparison_unknown"
+    if result.get("needs_update"):
+        return "needs_update"
+    return "up_to_date"
+
+
+def summarize(results: Sequence[Mapping[str, Any]], command: str) -> dict[str, int]:
+    """Build the tally for ``command``. Shapes differ per command by design."""
+    classes = [classify(result) for result in results]
+    total = len(results)
+    failed = classes.count("failed")
+    unknown = classes.count("comparison_unknown")
+
+    if command == "list":
+        return {"total": total, "failed": failed}
+
+    if command == "update":
+        updated = sum(1 for result in results if result.get("update_completed"))
+        # A device that was updated successfully now reports the new version and
+        # would classify as up_to_date — it must not be counted as skipped too.
+        skipped = sum(
+            1
+            for result, cls in zip(results, classes, strict=True)
+            if cls == "up_to_date" and not result.get("update_completed")
+        )
+        return {
+            "total": total,
+            "updated": updated,
+            "skipped": skipped,
+            "comparison_unknown": unknown,
+            "failed": failed,
+        }
+
+    return {
+        "total": total,
+        "up_to_date": classes.count("up_to_date"),
+        "needs_update": classes.count("needs_update"),
+        "comparison_unknown": unknown,
+        "failed": failed,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (22 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): classify results and build the per-command tally"
+```
+
+---
+
+### Task 3: Exit-code derivation
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `EXIT_OK`, `EXIT_OUTDATED`, `EXIT_ERROR`, `summarize()`.
+- Produces: `exit_code_for(command: str, summary: Mapping[str, int]) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def test_exit_code_ok_when_everything_current():
+    summary = cli.summarize([_result()], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_OK
+
+
+def test_exit_code_outdated_for_check():
+    summary = cli.summarize([_result(needs_update=True)], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_OUTDATED
+
+
+def test_exit_code_error_on_unknown_comparison():
+    summary = cli.summarize([_result(latest_version="Unknown")], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_error_beats_outdated():
+    results = [_result(ip="1", needs_update=True), _result(ip="2", success=False)]
+    summary = cli.summarize(results, "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_update_never_returns_one():
+    """A device that was just updated still carries needs_update from before."""
+    results = [_result(needs_update=True, update_completed=True)]
+    summary = cli.summarize(results, "update")
+    assert cli.exit_code_for("update", summary) == cli.EXIT_OK
+
+
+def test_exit_code_update_reports_failure():
+    results = [_result(success=False, update_started=True)]
+    summary = cli.summarize(results, "update")
+    assert cli.exit_code_for("update", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_list_reports_unreachable_device():
+    summary = cli.summarize([_result(success=False)], "list")
+    assert cli.exit_code_for("list", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_list_ignores_comparison():
+    summary = cli.summarize([_result(latest_version="Unknown")], "list")
+    assert cli.exit_code_for("list", summary) == cli.EXIT_OK
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'exit_code_for'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def exit_code_for(command: str, summary: Mapping[str, int]) -> int:
+    """Map a tally to an exit code. Error beats outdated beats ok."""
+    if summary.get("failed") or summary.get("comparison_unknown"):
+        return EXIT_ERROR
+    if command == "check" and summary.get("needs_update"):
+        return EXIT_OUTDATED
+    return EXIT_OK
+```
+
+Note that `list` needs no special case: its tally never carries
+`comparison_unknown` or `needs_update` keys, so only `failed` can raise it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (30 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): derive exit codes from the tally"
+```
+
+---
+
+### Task 4: Rendering — table and JSON
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `classify()`, `summarize()`.
+- Produces: `render_human(command: str, results: Sequence[Mapping[str, Any]], summary: Mapping[str, int]) -> str`, `render_json(command: str, devices_file: str, results: Sequence[Mapping[str, Any]], summary: Mapping[str, int], exit_code: int) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+import json
+
+
+def test_render_human_labels_each_class():
+    results = [
+        _result(ip="192.168.8.191", needs_update=True, dns_name="flur"),
+        _result(ip="192.168.8.192", dns_name="kueche"),
+        _result(ip="192.168.8.193", latest_version="Unknown", dns_name="bad"),
+        _result(ip="192.168.8.194", success=False, dns_name="keller"),
+    ]
+    text = cli.render_human("check", results, cli.summarize(results, "check"))
+    assert "192.168.8.191" in text
+    assert "Update verfügbar" in text
+    assert "aktuell" in text
+    assert "Vergleich unbekannt" in text
+    assert "nicht erreichbar" in text
+
+
+def test_render_human_uses_update_labels():
+    results = [
+        _result(ip="1", needs_update=True, update_completed=True),
+        _result(ip="2"),
+        _result(ip="3", success=False, update_started=True),
+    ]
+    text = cli.render_human("update", results, cli.summarize(results, "update"))
+    assert "aktualisiert" in text
+    assert "übersprungen" in text
+    assert "Update fehlgeschlagen" in text
+    assert "Update verfügbar" not in text
+
+
+def test_render_human_ends_with_the_tally():
+    results = [_result(needs_update=True)]
+    text = cli.render_human("check", results, cli.summarize(results, "check"))
+    assert text.splitlines()[-1] == "0 aktuell, 1 Update verfügbar, 0 Vergleich unbekannt, 0 Fehler"
+
+
+def test_render_json_is_parseable_and_complete():
+    results = [_result(needs_update=True)]
+    summary = cli.summarize(results, "check")
+    payload = json.loads(
+        cli.render_json("check", "devices.yaml", results, summary, cli.EXIT_OUTDATED)
+    )
+    assert payload["command"] == "check"
+    assert payload["devices_file"] == "devices.yaml"
+    assert payload["exit_code"] == cli.EXIT_OUTDATED
+    assert payload["summary"] == summary
+    assert payload["results"][0]["ip"] == "192.168.8.191"
+
+
+def test_render_json_passes_core_fields_through_unchanged():
+    results = [_result(message="anything the core said")]
+    payload = json.loads(cli.render_json("check", "d.yaml", results, {}, cli.EXIT_OK))
+    assert payload["results"][0]["message"] == "anything the core said"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'render_human'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import json` at the top of `app/cli.py`, then append:
+
+```python
+_CHECK_LABELS = {
+    "failed": "nicht erreichbar",
+    "comparison_unknown": "Vergleich unbekannt",
+    "needs_update": "Update verfügbar",
+    "up_to_date": "aktuell",
+}
+
+
+def _update_label(result: Mapping[str, Any]) -> str:
+    """Label for an update run. A just-updated device still carries
+    ``needs_update`` from its pre-update comparison, so the class alone lies."""
+    if result.get("update_completed"):
+        return "aktualisiert"
+    if not result.get("success"):
+        return "Update fehlgeschlagen" if result.get("update_started") else "nicht erreichbar"
+    if classify(result) == "comparison_unknown":
+        return "Vergleich unbekannt"
+    return "übersprungen (aktuell)"
+
+
+def _version_column(result: Mapping[str, Any]) -> str:
+    current = result.get("current_version") or "—"
+    if not result.get("success"):
+        return "—"
+    if classify(result) == "needs_update":
+        return f"{current} → {result.get('latest_version')}"
+    return str(current)
+
+
+def _tally_line(command: str, summary: Mapping[str, int]) -> str:
+    if command == "list":
+        return f"{summary.get('total', 0)} Geräte, {summary.get('failed', 0)} Fehler"
+    if command == "update":
+        return (
+            f"{summary.get('updated', 0)} aktualisiert, "
+            f"{summary.get('skipped', 0)} übersprungen, "
+            f"{summary.get('comparison_unknown', 0)} Vergleich unbekannt, "
+            f"{summary.get('failed', 0)} Fehler"
+        )
+    return (
+        f"{summary.get('up_to_date', 0)} aktuell, "
+        f"{summary.get('needs_update', 0)} Update verfügbar, "
+        f"{summary.get('comparison_unknown', 0)} Vergleich unbekannt, "
+        f"{summary.get('failed', 0)} Fehler"
+    )
+
+
+def render_human(
+    command: str,
+    results: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, int],
+) -> str:
+    """One line per device plus a closing tally, sized for a cron mail."""
+    lines = []
+    for result in results:
+        label = _update_label(result) if command == "update" else _CHECK_LABELS[classify(result)]
+        name = str(result.get("dns_name") or "")
+        lines.append(
+            f"{str(result.get('ip', '?')):<16}{name:<16}{_version_column(result):<20}{label}"
+        )
+    lines.append(_tally_line(command, summary))
+    return "\n".join(lines)
+
+
+def render_json(
+    command: str,
+    devices_file: str,
+    results: Sequence[Mapping[str, Any]],
+    summary: Mapping[str, int],
+    exit_code: int,
+) -> str:
+    """Emit the core result dicts unchanged, plus tally and exit code."""
+    payload = {
+        "command": command,
+        "devices_file": devices_file,
+        "results": [dict(result) for result in results],
+        "summary": dict(summary),
+        "exit_code": exit_code,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (35 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): render results as a table or JSON"
+```
+
+---
+
+### Task 5: `list` verb
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks beyond the module itself.
+- Produces: `cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]`.
+
+`cmd_list` calls `app.tasmota.updater.get_device_firmware_version(device)` per
+device and deliberately does **not** call `fetch_latest_tasmota_release()`. It
+returns result dicts shaped like the core's: `ip`, `dns_name`, `success`,
+`current_version`. No `latest_version`, no `needs_update`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def test_cmd_list_reports_firmware_without_release_lookup(monkeypatch):
+    calls = []
+
+    def fake_firmware(device):
+        calls.append(device["ip"])
+        return {"version": "15.0.1", "core_version": "2.7.4.9"}
+
+    def explode():  # must never be called
+        raise AssertionError("list must not perform a release lookup")
+
+    monkeypatch.setattr(cli.updater, "get_device_firmware_version", fake_firmware)
+    monkeypatch.setattr(cli.updater, "fetch_latest_tasmota_release", explode)
+
+    devices = [{"ip": "192.168.8.191", "dns_name": "flur"}, {"ip": "192.168.8.192"}]
+    results = cli.cmd_list(devices)
+
+    assert calls == ["192.168.8.191", "192.168.8.192"]
+    assert results[0] == {
+        "ip": "192.168.8.191",
+        "dns_name": "flur",
+        "success": True,
+        "current_version": "15.0.1",
+    }
+    assert "latest_version" not in results[0]
+
+
+def test_cmd_list_marks_unreachable_device(monkeypatch):
+    monkeypatch.setattr(cli.updater, "get_device_firmware_version", lambda device: None)
+    results = cli.cmd_list([{"ip": "192.168.8.193"}])
+    assert results[0]["success"] is False
+    assert results[0]["current_version"] == "Unknown"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'updater'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `from app.tasmota import jobs, updater, utils` to the imports in
+`app/cli.py` (`jobs` and `utils` are used by later tasks), then append:
+
+```python
+def cmd_list(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Inventory: what is configured and what firmware runs on it.
+
+    Deliberately LAN-only — no release lookup, so no GitHub rate limit can
+    break it, and it can never report "outdated".
+    """
+    results: list[dict[str, Any]] = []
+    for device in devices:
+        info = updater.get_device_firmware_version(dict(device))
+        result: dict[str, Any] = {
+            "ip": device.get("ip"),
+            "success": info is not None,
+            "current_version": (info or {}).get("version", UNKNOWN_VERSION),
+        }
+        if device.get("dns_name"):
+            result["dns_name"] = device["dns_name"]
+        results.append(result)
+    return results
+```
+
+Note the key order in the test: `dns_name` is inserted after `current_version`,
+and dict equality ignores order, so the assertion holds.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (37 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): add the list verb"
+```
+
+---
+
+### Task 6: `check` verb
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `jobs` import from Task 5.
+- Produces: `run_batch(devices: Sequence[Mapping[str, Any]], *, check_only: bool, timeout: int | None) -> list[dict[str, Any]]` (raises `CliError` when the runner refuses or fails), `cmd_check(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]`, `CliError(Exception)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def test_cmd_check_delegates_to_the_batch_runner(monkeypatch):
+    seen = {}
+
+    def fake_create(devices, check_only, update_only_needed, global_timeout, **kwargs):
+        seen.update(
+            devices=list(devices),
+            check_only=check_only,
+            update_only_needed=update_only_needed,
+            global_timeout=global_timeout,
+            background=kwargs.get("background"),
+        )
+        return "job-1"
+
+    monkeypatch.setattr(cli.jobs, "create_batch_job", fake_create)
+    monkeypatch.setattr(
+        cli.jobs,
+        "get_job",
+        lambda job_id: {"status": "completed", "results": [_result()], "error": None},
+    )
+
+    results = cli.cmd_check([{"ip": "192.168.8.191"}])
+
+    assert seen["check_only"] is True
+    assert seen["update_only_needed"] is False
+    assert seen["global_timeout"] is None
+    assert seen["background"] is False
+    assert results == [_result()]
+
+
+def test_run_batch_raises_when_the_runner_refuses(monkeypatch):
+    monkeypatch.setattr(cli.jobs, "create_batch_job", lambda *a, **k: None)
+    with pytest.raises(cli.CliError, match="batch job"):
+        cli.run_batch([{"ip": "1"}], check_only=True, timeout=None)
+
+
+def test_run_batch_raises_on_runner_error(monkeypatch):
+    monkeypatch.setattr(cli.jobs, "create_batch_job", lambda *a, **k: "job-1")
+    monkeypatch.setattr(
+        cli.jobs,
+        "get_job",
+        lambda job_id: {"status": "error", "results": [], "error": "boom"},
+    )
+    with pytest.raises(cli.CliError, match="boom"):
+        cli.run_batch([{"ip": "1"}], check_only=True, timeout=None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'CliError'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+class CliError(Exception):
+    """A condition that must end the run with EXIT_ERROR."""
+
+
+def run_batch(
+    devices: Sequence[Mapping[str, Any]],
+    *,
+    check_only: bool,
+    timeout: int | None,
+) -> list[dict[str, Any]]:
+    """Run the shared batch runner synchronously and return its results.
+
+    ``update_only_needed`` is always False: the CLI decides itself which
+    devices to touch, because the runner's internal filter drops skipped
+    devices from the results and would hide a failed comparison.
+    """
+    job_id = jobs.create_batch_job(
+        list(devices),
+        check_only=check_only,
+        update_only_needed=False,
+        global_timeout=timeout,
+        background=False,
+    )
+    if job_id is None:
+        raise CliError("Could not create a batch job — another one is already running.")
+    job = jobs.get_job(job_id)
+    if job is None:
+        raise CliError(f"Batch job {job_id} disappeared before it could be read.")
+    if job.get("status") == "error":
+        raise CliError(str(job.get("error") or "The batch runner failed."))
+    return [dict(result) for result in job.get("results", [])]
+
+
+def cmd_check(devices: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Compare every configured device against the latest release."""
+    return run_batch(devices, check_only=True, timeout=None)
+```
+
+`create_batch_job` takes `check_only`, `update_only_needed` and
+`global_timeout` positionally in its signature, but passing them by keyword as
+above is valid and clearer — only `updater`, `clock` and `background` are
+keyword-only.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (40 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): add the check verb over the shared batch runner"
+```
+
+---
+
+### Task 7: `update` verb — two passes
+
+**Files:**
+- Modify: `app/cli.py`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: `run_batch()`, `classify()`, `CliError`.
+- Produces: `cmd_update(devices: Sequence[Mapping[str, Any]], *, force: bool, timeout: int | None) -> list[dict[str, Any]]`.
+
+Pass one classifies every device (`check_only=True`). Pass two updates only the
+selected subset (`check_only=False`) and its results replace the pass-one
+entries for those devices. Devices that were not selected keep their pass-one
+result, so a failed comparison stays visible instead of silently vanishing.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def test_cmd_update_only_touches_outdated_devices(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
+        if check_only:
+            return [
+                _result(ip="1", needs_update=True),
+                _result(ip="2"),
+            ]
+        return [_result(ip="1", needs_update=True, update_completed=True, success=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+
+    results = cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)
+
+    assert passes[0] == {"ips": ["1", "2"], "check_only": True}
+    assert passes[1] == {"ips": ["1"], "check_only": False}
+    by_ip = {r["ip"]: r for r in results}
+    assert by_ip["1"]["update_completed"] is True
+    assert by_ip["2"].get("update_completed") is None
+    assert len(results) == 2
+
+
+def test_cmd_update_skips_the_second_pass_when_nothing_is_outdated(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append(check_only)
+        return [_result(ip="1")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+
+    assert passes == [True]
+    assert results == [_result(ip="1")]
+
+
+def test_cmd_update_does_not_flash_on_unknown_comparison(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append(check_only)
+        return [_result(ip="1", latest_version="Unknown")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+
+    assert passes == [True], "an unknown comparison must not trigger a flash"
+    assert cli.classify(results[0]) == "comparison_unknown"
+
+
+def test_cmd_update_force_updates_every_reachable_device(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
+        if check_only:
+            return [_result(ip="1"), _result(ip="2", success=False)]
+        return [_result(ip="1", update_completed=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=True, timeout=None)
+
+    assert passes[1] == {"ips": ["1"], "check_only": False}, "unreachable devices stay out"
+
+
+def test_cmd_update_passes_the_timeout_to_the_second_pass_only(monkeypatch):
+    seen = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        seen.append((check_only, timeout))
+        return [_result(ip="1", needs_update=True)] if check_only else [_result(ip="1")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    cli.cmd_update([{"ip": "1"}], force=False, timeout=300)
+
+    assert seen == [(True, None), (False, 300)]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'cmd_update'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def cmd_update(
+    devices: Sequence[Mapping[str, Any]],
+    *,
+    force: bool,
+    timeout: int | None,
+) -> list[dict[str, Any]]:
+    """Update outdated devices in two passes: classify, then flash the subset.
+
+    The runner's own ``update_only_needed`` filter is not used: it drops
+    skipped devices from the results, which would make a failed release lookup
+    indistinguishable from "everything current".
+    """
+    checked = run_batch(devices, check_only=True, timeout=None)
+    # With --force, up-to-date devices are flashed too — but never a device we
+    # could not classify: flashing blind is worse than doing nothing.
+    wanted = ("needs_update", "up_to_date") if force else ("needs_update",)
+    selected_ips = [result["ip"] for result in checked if classify(result) in wanted]
+    if not selected_ips:
+        return checked
+
+    by_ip = {device.get("ip"): device for device in devices}
+    subset = [by_ip[ip] for ip in selected_ips if ip in by_ip]
+    updated = {result.get("ip"): result for result in run_batch(
+        subset, check_only=False, timeout=timeout
+    )}
+    return [updated.get(result["ip"], result) for result in checked]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (45 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py
+git commit -m "feat(cli): add the update verb with a classify-then-flash pass"
+```
+
+---
+
+### Task 8: `main()` — wiring, logging, error paths
+
+**Files:**
+- Modify: `app/cli.py`
+- Modify: `pyproject.toml`
+- Test: `tests/test_cli.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `main(argv: Sequence[str] | None = None) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_cli.py
+
+
+def test_main_writes_only_json_to_stdout_at_debug_level(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 192.168.8.191\n", encoding="utf-8")
+    monkeypatch.setattr(cli, "cmd_check", lambda devices: [_result()])
+
+    code = cli.main(["-f", str(devices_file), "--json", "--log-level", "DEBUG", "check"])
+
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_OK
+    assert json.loads(captured.out)["command"] == "check"
+
+
+def test_main_reports_missing_devices_file(monkeypatch, capsys, tmp_path):
+    code = cli.main(["-f", str(tmp_path / "nope.yaml"), "check"])
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "nope.yaml" in captured.err
+
+
+def test_main_reports_empty_device_list(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices: []\n", encoding="utf-8")
+    code = cli.main(["-f", str(devices_file), "check"])
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_ERROR
+    assert "No devices" in captured.err
+
+
+def test_main_turns_cli_errors_into_exit_two(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 1\n", encoding="utf-8")
+
+    def explode(devices):
+        raise cli.CliError("runner said no")
+
+    monkeypatch.setattr(cli, "cmd_check", explode)
+    code = cli.main(["-f", str(devices_file), "check"])
+    assert code == cli.EXIT_ERROR
+    assert "runner said no" in capsys.readouterr().err
+
+
+def test_main_handles_interrupt_and_warns_about_the_running_flash(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 1\n", encoding="utf-8")
+
+    def interrupt(devices, *, force, timeout):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "cmd_update", interrupt)
+    code = cli.main(["-f", str(devices_file), "update"])
+    err = capsys.readouterr().err
+    assert code == cli.EXIT_ERROR
+    assert "weiter" in err  # the flash keeps running on the device
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.cli' has no attribute 'main'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import logging`, `import os`, `import sys` and `from pathlib import Path`
+to the imports, then append:
+
+```python
+def _configure_logging(level: str) -> None:
+    """All logging goes to stderr so stdout stays parseable with --json."""
+    logging.basicConfig(
+        level=getattr(logging, level),
+        stream=sys.stderr,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _load_env() -> None:
+    """Honour ENV_FILE like server.py does, so ENV_FILE=.env.dev works."""
+    env_file = Path(os.environ.get("ENV_FILE", ".env"))
+    if env_file.exists():
+        from dotenv import load_dotenv
+
+        load_dotenv(str(env_file))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns the exit code, never raises for expected failures."""
+    args = build_parser().parse_args(argv)
+    _configure_logging(args.log_level)
+    _load_env()
+
+    devices_file = resolve_devices_file(args.file, os.environ)
+    if not Path(devices_file).exists():
+        print(f"Devices file not found: {devices_file}", file=sys.stderr)
+        return EXIT_ERROR
+
+    devices = utils.load_devices_from_file(devices_file)
+    if not devices:
+        print(f"No devices configured in {devices_file}", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        if args.command == "list":
+            results = cmd_list(devices)
+        elif args.command == "check":
+            results = cmd_check(devices)
+        else:
+            results = cmd_update(devices, force=args.force, timeout=args.timeout)
+    except CliError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_ERROR
+    except KeyboardInterrupt:
+        print(
+            "Abgebrochen. Achtung: ein bereits gestarteter OTA-Flash läuft auf dem "
+            "Gerät weiter und wurde nicht zurückgenommen.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    summary = summarize(results, args.command)
+    code = exit_code_for(args.command, summary)
+    if args.json:
+        print(render_json(args.command, devices_file, results, summary, code))
+    else:
+        print(render_human(args.command, results, summary))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_cli.py -v -o addopts=""`
+Expected: PASS (50 tests)
+
+- [ ] **Step 5: Add the console-script entry point**
+
+In `pyproject.toml`, directly after the `[project.optional-dependencies]`
+block's end and before `[project.urls]`, insert:
+
+```toml
+[project.scripts]
+tasmota-updater = "app.cli:main"
+```
+
+This is a convenience for anyone who runs `pip install .`. The documented
+invocation stays `python -m app.cli`, because the project is not installed as a
+package anywhere — neither locally nor in the Containerfile.
+
+- [ ] **Step 6: Verify the module runs end to end against fake devices**
+
+Run: `ENV_FILE=.env.dev python -m app.cli list`
+Expected: one line per device from `devices-dev.yaml`, then a tally line, exit 0.
+
+Run: `echo $?`
+Expected: `0`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/cli.py tests/test_cli.py pyproject.toml
+git commit -m "feat(cli): wire up main() with logging, error paths and entry point"
+```
+
+---
+
+### Task 9: Smoke test against the fake devices
+
+**Files:**
+- Create: `tests/test_cli_smoke.py`
+
+**Interfaces:**
+- Consumes: the finished `app/cli.py`.
+- Produces: nothing other tasks use.
+
+The smoke test runs the CLI in a subprocess, the way `tests/e2e` runs the
+server. That rules out `monkeypatch` — it cannot reach into another process, and
+adding a test-only hook to production code is not worth it.
+
+**Third deviation from the design document:** the design said the release lookup
+would be stubbed for `check`. In a subprocess it cannot be, so `check` is
+asserted only on what holds no matter what the lookup returns — stdout is valid
+JSON, `exit_code` in the payload matches the process exit code, and the tally
+has exactly the documented keys. The real comparison behaviour is covered by the
+unit tests in Tasks 2–3, which is where it belongs. This keeps a live GitHub call
+from making the test flaky (#76) without pretending to control it.
+
+`list` needs no such care: it performs no release lookup at all.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_smoke.py
+"""End-to-end smoke test: run the CLI as a subprocess against fake devices."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "app.cli", "-f", "devices-dev.yaml", *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_list_json_reports_every_fake_device():
+    result = _run("list", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "list"
+    assert payload["summary"]["total"] >= 1
+    assert payload["summary"]["failed"] == 0
+    assert all("latest_version" not in entry for entry in payload["results"])
+
+
+def test_check_json_is_parseable_whatever_the_release_lookup_does():
+    result = _run("check", "--json")
+    assert result.returncode in (0, 1, 2), result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "check"
+    assert payload["exit_code"] == result.returncode
+    assert set(payload["summary"]) == {
+        "total",
+        "up_to_date",
+        "needs_update",
+        "comparison_unknown",
+        "failed",
+    }
+
+
+def test_human_output_ends_with_a_tally():
+    result = _run("list")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[-1].endswith("Fehler")
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes for the right reason**
+
+Run: `python -m pytest tests/test_cli_smoke.py -v -o addopts=""`
+Expected: PASS. If `test_list_json_reports_every_fake_device` fails, the fake
+device path in `updater.get_device_firmware_version()` is not being taken —
+check that `devices-dev.yaml` entries carry `fake: true`.
+
+- [ ] **Step 3: Run the whole green core**
+
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+Expected: PASS, including the pre-existing `tests/test_cli_deprecated.py`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_cli_smoke.py
+git commit -m "test(cli): smoke-test the CLI against the fake devices"
+```
+
+---
+
+### Task 10: Documentation reconciliation
+
+**Files:**
+- Modify: `tasmota_updater.py`
+- Modify: `docs/cli-usage.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+- Modify: `docs/audit-2026-07/implementation-plan.md`
+
+**Interfaces:**
+- Consumes: the finished CLI.
+- Produces: nothing.
+
+- [ ] **Step 1: Point the deprecation stub at the new command**
+
+In `tasmota_updater.py`, replace the `_MESSAGE` body with:
+
+```python
+_MESSAGE = """\
+tasmota_updater.py — the old command-line interface — is gone. It duplicated the
+update logic and had drifted out of sync with it.
+
+There is a new, thin CLI over the maintained core:
+  * python -m app.cli check      compare every device against the latest release
+  * python -m app.cli update     update every outdated device
+  * python -m app.cli list       list configured devices and their firmware
+
+Other interfaces:
+  * Web UI:   python server.py   ->  http://localhost:5001
+  * REST API: POST /api/update, POST /api/update/all   (docs at /apidocs/)
+
+The options of the old CLI (-f/--file aside) do not carry over: --update-all,
+--check-only, --dry-run and --example are gone. See docs/cli-usage.md.
+"""
+```
+
+Keep `main()` returning 1 and keep the word "deprecated" out of the message only
+if `tests/test_cli_deprecated.py` still passes — it asserts
+`"deprecated" in result.stderr.lower()`. It does **not** pass with the text
+above, so update that test in the same commit:
+
+```python
+# tests/test_cli_deprecated.py — replace the two assertions
+    assert result.returncode == 1
+    assert "python -m app.cli" in result.stderr
+    assert "Traceback" not in result.stderr
+```
+
+- [ ] **Step 2: Rewrite `docs/cli-usage.md`**
+
+Replace the deprecation banner and the historical content with the current
+surface: the three verbs, the option table, the exit-code table, the JSON shape,
+and two cron examples. State explicitly that the old options
+(`--update-all`, `--check-only`, `--dry-run`, `--example`, the configuration
+wizard) no longer exist, and that the documented invocation is
+`python -m app.cli` because the project is not installed as a package. Copy the
+exit-code table and the `Vergleich unbekannt` rule from
+`docs/audit-2026-07/2026-07-28-cli-design.md` so the two documents agree.
+
+- [ ] **Step 3: Fix `README.md`**
+
+Change "**Two supported interfaces in one tool:**" to three and add the CLI
+bullet. Remove the paragraph stating that the command-line interface is
+deprecated and no longer works, and change the documentation link
+`- [Command-Line Usage](docs/cli-usage.md) *(deprecated)*` to drop the
+`*(deprecated)*` marker. Run `grep -c '^```' README.md` and confirm the count is
+even.
+
+- [ ] **Step 4: Fix `CLAUDE.md`**
+
+In the "Running the Application" section, replace the paragraph beginning
+"There is **no working CLI**." with a description of the new CLI: the three
+verbs, `python -m app.cli`, the exit-code contract, and the note that it is a
+thin wrapper that must never grow its own update logic. In "Application
+Structure", change the `tasmota_updater.py` entry to point at `app/cli.py`.
+
+- [ ] **Step 5: Mark the backlog item done**
+
+In `docs/audit-2026-07/implementation-plan.md`, change the heading
+"**Offen / Backlog — dünne CLI-Schicht für Automatisierungen.**" to mark it
+done, link both `2026-07-28-cli-design.md` and `2026-07-28-cli-plan.md`, and
+record the deviations: verbs instead of flags, no `--dry-run`, no
+`--non-interactive`, no single-device verb, `python -m app.cli` instead of a
+console script.
+
+- [ ] **Step 6: Verify the documentation builds and the tests still pass**
+
+Run: `uv run --with mkdocs-material mkdocs build --strict`
+Expected: no warnings that fail the build.
+
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tasmota_updater.py tests/test_cli_deprecated.py docs/cli-usage.md README.md CLAUDE.md docs/audit-2026-07/implementation-plan.md
+git commit -m "docs(cli): document the new CLI and retire the deprecation wording"
+```
+
+---
+
+## Opening the pull request
+
+PR title: `feat(cli): add a thin CLI over the maintained core`. The `feat` type
+is deliberate — it produces a minor version bump, which is what a new interface
+warrants.
+
+The PR body should state what the design decided against (`--dry-run`,
+interactive prompts, parallelism, single-device verb) and name the one risk that
+CI cannot cover: `update` against real hardware is unverified, because fake
+devices do not reproduce the OTA flash window (same limitation as #87).

--- a/docs/audit-2026-07/2026-07-28-cli-plan.md
+++ b/docs/audit-2026-07/2026-07-28-cli-plan.md
@@ -35,8 +35,12 @@ release lookup would look exactly like "everything current" — the very trap th
 design forbids. Instead:
 
 1. Pass one: `create_batch_job(devices, check_only=True, update_only_needed=False, …)` — classify every device.
-2. Pass two: `create_batch_job(subset, check_only=False, update_only_needed=False, …)` where `subset` is the devices classified `needs_update` (with `--force`: every successfully reached device).
+2. Pass two: `create_batch_job(subset, check_only=False, update_only_needed=False, …)` where `subset` is the devices classified `needs_update`.
 3. Merge pass-two results with the pass-one results of the untouched devices.
+
+(`--force` was dropped from the final PR — see the note under Task 7 below —
+so `subset` is always exactly the `needs_update` devices, never "every
+successfully reached device".)
 
 Side effect: this also removes the double-check noted in the design, because
 pass two is called with `update_only_needed=False` and does not filter again.
@@ -106,15 +110,14 @@ def test_parser_accepts_each_command(command):
 
 
 def test_parser_accepts_update_options():
-    args = cli.build_parser().parse_args(["update", "--timeout", "300", "--force"])
+    args = cli.build_parser().parse_args(["update", "--timeout", "300"])
     assert args.timeout == 300
-    assert args.force is True
 
 
 @pytest.mark.parametrize("command", ["check", "list"])
 def test_parser_rejects_update_options_on_other_commands(command):
     with pytest.raises(SystemExit):
-        cli.build_parser().parse_args([command, "--force"])
+        cli.build_parser().parse_args([command, "--timeout", "300"])
 
 
 def test_resolve_devices_file_prefers_explicit_path():
@@ -180,11 +183,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--timeout",
         type=int,
         help="Override the per-device total timeout in seconds.",
-    )
-    update.add_argument(
-        "--force",
-        action="store_true",
-        help="Flash every configured device, including up-to-date ones.",
     )
     return parser
 
@@ -899,12 +897,21 @@ git commit -m "feat(cli): add the check verb over the shared batch runner"
 
 **Interfaces:**
 - Consumes: `run_batch()`, `classify()`, `CliError`.
-- Produces: `cmd_update(devices: Sequence[Mapping[str, Any]], *, force: bool, timeout: int | None) -> list[dict[str, Any]]`.
+- Produces: `cmd_update(devices: Sequence[Mapping[str, Any]], *, timeout: int | None) -> list[dict[str, Any]]`.
 
 Pass one classifies every device (`check_only=True`). Pass two updates only the
 selected subset (`check_only=False`) and its results replace the pass-one
 entries for those devices. Devices that were not selected keep their pass-one
 result, so a failed comparison stays visible instead of silently vanishing.
+
+**`--force` was cut from the final PR, after this plan was written.** The core
+(`update_device_firmware()` in `app/tasmota/updater.py`) returns early with
+`success=True` when a device already reports the current version, without
+flashing it — so `--force` reported "aktualisiert" and exit 0 for a device it
+never touched. Making it work needs a core change, tracked separately.
+`cmd_update()` therefore always selects only `needs_update` devices; the
+snippets below still show `force` because they predate that fix and are kept
+as the historical record of what was planned and then reverted.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/audit-2026-07/implementation-plan.md
+++ b/docs/audit-2026-07/implementation-plan.md
@@ -64,21 +64,33 @@ funktionsunfähig. **Entscheidung: deprecaten** — die ~900 Zeilen duplizierten
 die Update-Logik aus `app/tasmota` und waren davon weggelaufen. Heute ist die
 Datei ein Stub (Notice auf stderr, Exit 1).
 
-**Offen / Backlog — dünne CLI-Schicht für Automatisierungen.** Der
+**Dünne CLI-Schicht für Automatisierungen — ✅ erledigt.** Der
 Deprecation-Grund war die *Duplikation*, nicht der Nutzen: ein CLI ist für
-Cron/Skripte weiterhin sinnvoll (Wunsch des Users, 2026-07-26). Nachziehen als
-dünner Wrapper **über** dem gepflegten Kern in `app/tasmota` — keine zweite
-Kopie der Logik:
+Cron/Skripte weiterhin sinnvoll (Wunsch des Users, 2026-07-26). Umgesetzt als
+dünner Wrapper **über** dem gepflegten Kern in `app/tasmota`, ohne zweite
+Kopie der Logik — Design und Plan:
+[`2026-07-28-cli-design.md`](2026-07-28-cli-design.md),
+[`2026-07-28-cli-plan.md`](2026-07-28-cli-plan.md).
 
-- Optionen wie früher: `-f/--file`, `--check-only`, `--dry-run`, `--update-all`,
-  `--non-interactive`, `--log-level`.
-- Ruft `update_device_firmware()` / den Job-Runner direkt auf, ohne laufenden
-  Server und ohne API-Key (das ist der Vorteil gegenüber `curl` auf die REST-API).
-- Exit-Codes maschinenlesbar (0 = nichts zu tun / alles aktualisiert, ≠ 0 =
-  Fehler), Ausgabe optional als JSON für Weiterverarbeitung.
-- Tests: Unit über den Wrapper (Kern gemockt) + ein Smoke-Lauf gegen Fake-Devices.
-- `docs/cli-usage.md` und die README-Feature-Liste („Three powerful interfaces")
-  wieder in Einklang bringen.
+Abweichungen vom ursprünglichen Backlog-Eintrag oben:
+
+- **Verben statt Flags:** `python -m app.cli {check|update|list}` statt
+  `--check-only`/`--update-all`. Drei Verben sind klarer, und die alte Syntax
+  war ohnehin nicht kompatibel.
+- **Kein `--dry-run`:** doppelt zum Verb `check`.
+- **Kein `--non-interactive`:** die CLI ist immer nicht-interaktiv; kein
+  Wizard, keine Bestätigungsabfrage vor `update`.
+- **Kein Einzelgeräte-Verb** (`update <ip>`): kein Bedarf, die Web-UI deckt
+  Ad-hoc-Eingriffe ab.
+- **Aufruf bleibt `python -m app.cli`,** kein Konsolen-Skript: das Projekt
+  wird nirgends installiert (weder lokal noch im Containerfile), ein
+  Entry-Point ohne Installation existiert nicht. (`pyproject.toml` bekommt
+  trotzdem einen `[project.scripts]`-Eintrag für den Fall einer Installation —
+  die Doku verspricht ihn aber nicht als Standardweg.)
+- `-f/--file` und `--log-level` blieben erhalten.
+
+`docs/cli-usage.md` und die README-Feature-Liste sind wieder in Einklang mit
+dem Ist-Zustand.
 
 ### Phase 5 — Architektur & Wartbarkeit · #73  (teilweise erledigt)
 `updater.py` entflechten; Cache-Locking über Worker; Excepts differenzieren;

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,177 +1,179 @@
 # Command-Line Usage Guide
 
-> **⚠️ Deprecated.** The command-line interface is deprecated and no longer
-> maintained. It duplicated (and had drifted out of sync with) the core update
-> logic. Use the **Web Interface** (`python server.py` or the container image)
-> or the **REST API** (`POST /api/update`, `POST /api/update/all`) instead —
-> both share the maintained core in `app/tasmota`. Running `tasmota_updater.py`
-> now only prints a deprecation notice and exits. The content below is retained
-> for historical reference.
+There is a thin CLI over the maintained core in `app/tasmota`: `python -m
+app.cli`. It contains **no update logic of its own** — it resolves the device
+list and calls into the same code the web UI and the REST API use.
 
-The Tasmota Remote Updater includes a powerful command-line interface that allows you to update multiple devices at once, check firmware versions, and more.
+The old `tasmota_updater.py` script is gone. Its options
+(`--update-all`, `--check-only`, `--dry-run`, `--example` and the interactive
+configuration wizard) do **not** carry over — running `tasmota_updater.py` now
+only prints a pointer to this CLI and exits 1.
+
+The documented invocation is always `python -m app.cli`, not a standalone
+command, because the project is not installed as a package anywhere (not
+locally, not in the container image). A `[project.scripts]` entry
+(`tasmota-updater`) exists in `pyproject.toml`, but it only works after `pip
+install .`, which nothing in this repo does — don't rely on it.
 
 ## Basic Usage
 
 ```bash
-# If using a virtual environment, make sure it's activated first
-source venv/bin/activate  # For standard venv (bash/zsh)
-# OR
-source .venv/bin/activate  # For uv (bash/zsh)
-
-# Then run the script
-python tasmota_updater.py
+python -m app.cli check
+python -m app.cli update
+python -m app.cli list
 ```
 
-## Setting Up Device List
-
-The script uses a YAML file named `devices.yaml` to store your Tasmota device information.
-
-### Interactive Configuration Wizard
-
-When you run the script for the first time, an interactive configuration wizard will guide you through setting up your devices:
-
-1. The wizard will prompt you to enter the IP address for each device
-2. For each device, you can optionally provide authentication credentials (username and password)
-3. When you're finished adding devices, simply press Enter without typing an IP address
-
-**Example of the interactive wizard:**
-
-```
-=== Tasmota Device Configuration Wizard ===
-
-This wizard will help you create a configuration file for your Tasmota devices.
-You'll be prompted to enter information for each device.
-When you're finished adding devices, just press Enter without typing an IP address.
-
---- Device #1 ---
-Enter device IP address (or press Enter to finish): 192.168.1.100
-
-Authentication (leave empty if not required):
-Username (default: empty): admin
-Password (default: empty): secret
-Device #1 added successfully!
-
---- Device #2 ---
-Enter device IP address (or press Enter to finish): 192.168.1.101
-
-Authentication (leave empty if not required):
-Username (default: empty): 
-Password (default: empty): 
-Device #2 added successfully!
-
---- Device #3 ---
-Enter device IP address (or press Enter to finish): 
-
-Configuration saved to devices.yaml
-Found 2 device(s) in the configuration
-```
-
-### Manual Configuration
-
-If you prefer to create or edit the file manually, use this format:
-
-```yaml
-devices:
-  - ip: 192.168.1.100
-    username: admin  # optional
-    password: secret # optional
-  - ip: 192.168.1.101
-  - ip: 192.168.1.102
-    username: admin
-    password: mypass
-```
-
-> **Note:** The `devices.yaml` file is excluded from version control in the `.gitignore` file to prevent accidentally committing your device credentials.
-
-## Command-line Arguments
-
-The script supports several command-line arguments:
-
-```
-usage: tasmota_updater.py [-h] [-f FILE] [--example] [--non-interactive] [--dry-run] [--check-only] [--update-all] [--log-file LOG_FILE] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
-
-Update Tasmota devices over your network
-
-options:
-  -h, --help            show this help message and exit
-  -f FILE, --file FILE  Path to devices configuration file (default: devices.yaml)
-  --example             Create an example configuration file and exit
-  --non-interactive     Don't use interactive prompts, create example file if needed
-  --dry-run             Simulate the update process without making any changes
-  --check-only          Only check firmware versions without updating any devices
-  --update-all          Update all devices even if they are already running the latest version
-  --log-file LOG_FILE   Path to log file (default: logs/tasmota_updater.log)
-  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Logging level (default: INFO)
-```
-
-## Common Use Cases
-
-### Creating an Example Configuration
+In a container, without a new build layer:
 
 ```bash
-python tasmota_updater.py --example
+podman run --rm -v ./devices.yaml:/app/devices.yaml:ro \
+  --entrypoint python dodjango/tasmota-updater -m app.cli check
 ```
 
-### Using a Custom Configuration File
+## The Three Verbs
+
+| Verb | What it does | Talks to GitHub? |
+|---|---|---|
+| `check` | Compares every configured device against the latest Tasmota release. Reports, never flashes. | Yes |
+| `update` | Classifies every device first, then flashes the outdated ones (or, with `--force`, all reachable ones). | Yes |
+| `list` | Lists configured devices and the firmware they report. No release lookup at all. | No |
+
+`list` is immune to GitHub rate limits and can never report a device as
+outdated — it doesn't compare anything. Use it as a plain inventory source.
+
+## Options
+
+Shared options go **after** the verb:
+
+```
+python -m app.cli {check|update|list} [-f PATH] [--json] [--log-level LEVEL]
+python -m app.cli update [--timeout SECONDS] [--force]
+```
+
+`python -m app.cli list --json` works. `python -m app.cli --json list` does
+not — the shared options belong to the subcommand parser, not the top-level
+one.
+
+| Option | Meaning |
+|---|---|
+| `-f`, `--file PATH` | Path to the devices YAML file. Resolved like the server: an explicit `-f` wins, otherwise `DEVICES_FILE` from the environment/`.env`, otherwise `devices.yaml`. |
+| `--json` | Emit a JSON object on stdout instead of a table. |
+| `--log-level LEVEL` | `DEBUG`, `INFO`, `WARNING` (default) or `ERROR`. Logs go to stderr, never stdout, so `--json` output stays parseable regardless of the level. |
+| `--timeout SECONDS` | `update` only. Overrides the per-device total timeout. |
+| `--force` | `update` only. Flashes every configured device, including up-to-date ones — but never a device that could not be reached or classified. |
+
+Without `--force`, `update` only touches devices it classified as outdated —
+the safe default for an unattended run.
+
+## Output
+
+stdout carries only the result; stderr carries logs and errors.
+
+### Human-readable (default)
+
+One line per device plus a closing tally:
+
+```
+192.168.100.101  fake-tasmota-light1.local  12.0.2
+192.168.100.102  fake-tasmota-switch1.local  11.1.0
+192.168.100.103  fake-tasmota-plug1.local  12.0.2(tasmota-minimal)
+192.168.100.104  fake-tasmota-slow-device.local  11.0.0
+4 Geräte, 0 Fehler
+```
+
+(That example is `list` against the fake devices in `devices-dev.yaml` — the
+German tally wording is user-visible output, not a translation gap.) For
+`check`, a device carries one of four labels: `aktuell`, `Update verfügbar`,
+`Vergleich unbekannt`, or `nicht erreichbar`.
+
+### JSON (`--json`)
+
+The core's own result dicts, unchanged, plus a computed summary and the exit
+code:
+
+```json
+{
+  "command": "check",
+  "devices_file": "devices.yaml",
+  "results": [
+    {
+      "ip": "192.168.8.191",
+      "success": true,
+      "current_version": "14.6.0",
+      "latest_version": "15.0.1",
+      "needs_update": true,
+      "message": "..."
+    }
+  ],
+  "summary": {
+    "total": 4,
+    "up_to_date": 1,
+    "needs_update": 1,
+    "comparison_unknown": 1,
+    "failed": 1
+  },
+  "exit_code": 2
+}
+```
+
+`summary` is computed by the CLI itself from `results`, not taken from the
+job runner's own tally — the runner's summary has no way to express
+"comparison unknown" and does not distinguish "up to date" from "not
+comparable". `list` results omit the comparison fields (`latest_version`,
+`needs_update`); its summary has only `total` and `failed`.
+
+## Exit Codes
+
+| | `check` | `update` | `list` |
+|---|---|---|---|
+| **0** | everything up to date | nothing to do, or all updates succeeded | every device reachable |
+| **1** | at least one device outdated | — | — |
+| **2** | error | at least one update failed | at least one device unreachable |
+
+On mixed results the higher code wins: error (2) beats outdated (1) beats ok
+(0). Exit code 1 only ever occurs for `check`.
+
+**The rule that makes the exit codes trustworthy:** `needs_update: false` also
+means "could not compare" — a failed release lookup reports
+`latest_version: "Unknown"`. That case is never rendered as "up to date, exit
+0"; it is an error (exit 2) and renders as `Vergleich unbekannt`. A cron job
+that silently never alerts because of a rate-limited GitHub lookup would be
+worse than one that never ran.
+
+Other error conditions that produce exit 2: a missing or invalid devices
+file, an empty device list, duplicate IPs in the devices file (rejected
+before any device is touched), and an unreachable device.
+
+## Automation Examples
+
+The exit codes are the point — no `jq`, no output parsing needed for a simple
+alert:
 
 ```bash
-python tasmota_updater.py -f my_devices.yaml
+# Nightly check: alert only if something needs attention.
+python -m app.cli check || mail -s "Tasmota veraltet" me@example.com
 ```
-
-### Dry Run Mode (Simulation)
 
 ```bash
-python tasmota_updater.py --dry-run
+# Unattended weekly update, with a plain-text log for later inspection.
+0 3 * * 0 cd /path/to/tasmota-updater && \
+  python -m app.cli update --log-level INFO >> /var/log/tasmota-cli.log 2>&1
 ```
-
-### Check Firmware Versions Without Updating
 
 ```bash
-python tasmota_updater.py --check-only
+# Inventory for a monitoring script, no GitHub call and no rate-limit risk.
+python -m app.cli list --json
 ```
 
-### Update All Devices (Even Up-to-Date Ones)
+## Interrupting a Run
 
-```bash
-python tasmota_updater.py --update-all
-```
-
-### Specify Custom Log File
-
-```bash
-python tasmota_updater.py --log-file /var/log/tasmota_updates.log
-```
-
-### Use Debug Logging Level
-
-```bash
-python tasmota_updater.py --log-level DEBUG
-```
-
-## Logging
-
-The script logs all operations to both the console and a log file. By default, logs are stored in `logs/tasmota_updater.log`.
-
-Log levels available:
-
-- **DEBUG**: Detailed information, typically useful for diagnosing problems
-- **INFO**: Confirmation that things are working as expected (default)
-- **WARNING**: Indication that something unexpected happened, but the script is still working
-- **ERROR**: Due to a more serious problem, the script has not been able to perform some function
-- **CRITICAL**: A serious error, indicating that the script may be unable to continue running
-
-## Automation
-
-You can schedule regular updates using cron jobs:
-
-```bash
-# Example cron job to run updates every Sunday at 3 AM
-0 3 * * 0 cd /path/to/tasmota-updater && python tasmota_updater.py >> /var/log/tasmota_updates.log 2>&1
-```
+`Ctrl-C` during `update` is caught: the CLI prints a warning to stderr and
+exits 2. An OTA flash already started on a device keeps running there — it is
+not, and cannot be, aborted from the CLI.
 
 ## Next Steps
 
 - [Web Interface Guide](web-interface.md)
+- [API Documentation](api.md)
 - [Configuration Options](configuration.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -82,45 +82,97 @@ One line per device plus a closing tally:
 ```
 
 (That example is `list` against the fake devices in `devices-dev.yaml` — the
-German tally wording is user-visible output, not a translation gap.) For
-`check`, a device carries one of four labels: `aktuell`, `Update verfügbar`,
-`Vergleich unbekannt`, or `nicht erreichbar`.
+German tally wording is user-visible output, not a translation gap.)
+
+`check` against the same fixture, all four fake devices outdated:
+
+```
+192.168.100.101  fake-tasmota-light1.local  12.0.2 → 15.5.0     Update verfügbar
+192.168.100.102  fake-tasmota-switch1.local  11.1.0 → 15.5.0     Update verfügbar
+192.168.100.103  fake-tasmota-plug1.local  12.0.2(tasmota-minimal) → 15.5.0  Update verfügbar
+192.168.100.104  fake-tasmota-slow-device.local  11.0.0 → 15.5.0     Update verfügbar
+0 aktuell, 4 Update verfügbar, 0 Vergleich unbekannt, 0 Fehler
+```
+
+Note the third line: the version column (`12.0.2(tasmota-minimal) →
+15.5.0`) is wider than its usual padding, and the label still starts two
+spaces after it rather than gluing onto it — the columns are joined with a
+fixed separator, not built from fixed-width padding alone, so an overrunning
+column can never swallow the one after it. A device carries one of four
+labels: `aktuell`, `Update verfügbar`, `Vergleich unbekannt`, or `nicht
+erreichbar`.
 
 ### JSON (`--json`)
 
 The core's own result dicts, unchanged, plus a computed summary and the exit
-code:
+code. `json.dumps(..., sort_keys=True)` sorts keys alphabetically, and every
+result carries all the fields the core returns, not just the ones relevant
+to comparison — the excerpt below is a real, unedited run against two
+devices (one fake, one with a bad IP, to show a real failure) and is not
+representative of every field an update-vs-check run can carry:
 
 ```json
 {
   "command": "check",
-  "devices_file": "devices.yaml",
+  "devices_file": "devices-doc-example.yaml",
+  "exit_code": 2,
   "results": [
     {
-      "ip": "192.168.8.191",
-      "success": true,
-      "current_version": "14.6.0",
-      "latest_version": "15.0.1",
+      "current_version": "12.0.2",
+      "dns_name": "fake-tasmota-light1.local",
+      "ip": "192.168.100.101",
+      "latest_version": "15.5.0",
+      "message": "Update available",
       "needs_update": true,
-      "message": "..."
+      "success": true,
+      "timeout_config": {
+        "initial_wait": 10,
+        "max_check_interval": 30.0,
+        "min_check_interval": 2.0,
+        "total_timeout": 240
+      },
+      "timeout_report": null,
+      "update_completed": false,
+      "update_started": false,
+      "version_verification": null
+    },
+    {
+      "current_version": "Unknown",
+      "dns_name": "localhost",
+      "ip": "127.0.0.1",
+      "latest_version": "Unknown",
+      "message": "Failed to get current firmware version",
+      "needs_update": false,
+      "success": false,
+      "timeout_config": {
+        "initial_wait": 10,
+        "max_check_interval": 30.0,
+        "min_check_interval": 2.0,
+        "total_timeout": 240
+      },
+      "timeout_report": null,
+      "update_completed": false,
+      "update_started": false,
+      "version_verification": null
     }
   ],
   "summary": {
-    "total": 4,
-    "up_to_date": 1,
+    "comparison_unknown": 0,
+    "failed": 1,
     "needs_update": 1,
-    "comparison_unknown": 1,
-    "failed": 1
-  },
-  "exit_code": 2
+    "total": 2,
+    "up_to_date": 0
+  }
 }
 ```
 
-`summary` is computed by the CLI itself from `results`, not taken from the
-job runner's own tally — the runner's summary has no way to express
-"comparison unknown" and does not distinguish "up to date" from "not
-comparable". `list` results omit the comparison fields (`latest_version`,
-`needs_update`); its summary has only `total` and `failed`.
+`exit_code` is **2** here, not 1, because the unreachable device's failure
+beats "outdated" — see Exit Codes below. `summary` is computed by the CLI
+itself from `results`, not taken from the job runner's own tally — the
+runner's summary has no way to express "comparison unknown" and does not
+distinguish "up to date" from "not comparable". `list` results omit the
+comparison fields (`latest_version`, `needs_update`); its summary has only
+`total` and `failed`.
 
 ## Exit Codes
 
@@ -128,10 +180,19 @@ comparable". `list` results omit the comparison fields (`latest_version`,
 |---|---|---|---|
 | **0** | everything up to date | nothing to do, or all updates succeeded | every device reachable |
 | **1** | at least one device outdated | — | — |
-| **2** | error | at least one update failed | at least one device unreachable |
+| **2** | error | at least one flash failed, or a device could not be reached or compared — including one `update` never touched | at least one device unreachable |
 
 On mixed results the higher code wins: error (2) beats outdated (1) beats ok
 (0). Exit code 1 only ever occurs for `check`.
+
+For `update`, exit 2 does not necessarily mean a flash attempt failed:
+`update` classifies every device first and only flashes the ones it selected
+(outdated ones, or — with `--force` — every reachable, comparable one). A
+device it could not reach or could not compare is never flashed at all, but
+it still counts toward `failed`/`comparison_unknown` and still raises the
+exit code to 2. An operator debugging an exit-2 alert should check *which*
+device carries the `nicht erreichbar` or `Vergleich unbekannt` label before
+assuming a flash went wrong — it may be a device `update` never touched.
 
 **The rule that makes the exit codes trustworthy:** `needs_update: false` also
 means "could not compare" — a failed release lookup reports

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -35,7 +35,7 @@ podman run --rm -v ./devices.yaml:/app/devices.yaml:ro \
 | Verb | What it does | Talks to GitHub? |
 |---|---|---|
 | `check` | Compares every configured device against the latest Tasmota release. Reports, never flashes. | Yes |
-| `update` | Classifies every device first, then flashes the outdated ones (or, with `--force`, all reachable ones). | Yes |
+| `update` | Classifies every device first, then flashes the outdated ones. | Yes |
 | `list` | Lists configured devices and the firmware they report. No release lookup at all. | No |
 
 `list` is immune to GitHub rate limits and can never report a device as
@@ -47,7 +47,7 @@ Shared options go **after** the verb:
 
 ```
 python -m app.cli {check|update|list} [-f PATH] [--json] [--log-level LEVEL]
-python -m app.cli update [--timeout SECONDS] [--force]
+python -m app.cli update [--timeout SECONDS]
 ```
 
 `python -m app.cli list --json` works. `python -m app.cli --json list` does
@@ -60,10 +60,12 @@ one.
 | `--json` | Emit a JSON object on stdout instead of a table. |
 | `--log-level LEVEL` | `DEBUG`, `INFO`, `WARNING` (default) or `ERROR`. Logs go to stderr, never stdout, so `--json` output stays parseable regardless of the level. |
 | `--timeout SECONDS` | `update` only. Overrides the per-device total timeout. |
-| `--force` | `update` only. Flashes every configured device, including up-to-date ones — but never a device that could not be reached or classified. |
 
-Without `--force`, `update` only touches devices it classified as outdated —
-the safe default for an unattended run.
+`update` only touches devices it classified as outdated. Re-flashing a
+device that already reports the current version is not supported — the core
+skips it and reports success without touching the device (see
+`update_device_firmware()` in `app/tasmota/updater.py`), so a device that
+misreports its own version cannot be recovered through the CLI today.
 
 ## Output
 
@@ -187,12 +189,12 @@ On mixed results the higher code wins: error (2) beats outdated (1) beats ok
 
 For `update`, exit 2 does not necessarily mean a flash attempt failed:
 `update` classifies every device first and only flashes the ones it selected
-(outdated ones, or — with `--force` — every reachable, comparable one). A
-device it could not reach or could not compare is never flashed at all, but
-it still counts toward `failed`/`comparison_unknown` and still raises the
-exit code to 2. An operator debugging an exit-2 alert should check *which*
-device carries the `nicht erreichbar` or `Vergleich unbekannt` label before
-assuming a flash went wrong — it may be a device `update` never touched.
+as outdated. A device it could not reach or could not compare is never
+flashed at all, but it still counts toward `failed`/`comparison_unknown` and
+still raises the exit code to 2. An operator debugging an exit-2 alert should
+check *which* device carries the `nicht erreichbar` or `Vergleich unbekannt`
+label before assuming a flash went wrong — it may be a device `update` never
+touched.
 
 **The rule that makes the exit codes trustworthy:** `needs_update: false` also
 means "could not compare" — a failed release lookup reports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ test = [
     "hypothesis>=6.82.0",
 ]
 
+[project.scripts]
+tasmota-updater = "app.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/arendst/tasmota"
 Repository = "https://github.com/arendst/tasmota"

--- a/tasmota_updater.py
+++ b/tasmota_updater.py
@@ -1,25 +1,30 @@
 #!/usr/bin/env python3
-"""Deprecated command-line interface for the Tasmota Remote Updater.
+"""Retired command-line interface for the Tasmota Remote Updater.
 
-The CLI is deprecated and no longer maintained. It duplicated the core update
-logic (and had drifted out of sync with it). Use the web interface or the REST
-API instead, which share the maintained core in ``app/tasmota``.
+This entry point is gone: it duplicated the core update logic and had drifted
+out of sync with it. A new, thin CLI over the maintained core lives at
+``app/cli.py`` — invoke it as ``python -m app.cli``.
 
 This stub remains only to give anyone still invoking the old entry point a clear
-message and a pointer to the supported interfaces.
+message and a pointer to the new one.
 """
 import sys
 
 _MESSAGE = """\
-tasmota_updater.py — the command-line interface — is deprecated and no longer
-maintained.
+tasmota_updater.py — the old command-line interface — is gone. It duplicated the
+update logic and had drifted out of sync with it.
 
-Use one of the supported interfaces instead:
-  * Web UI:    python server.py        ->  http://localhost:5001
-  * Container: see README.md / compose.example.yml
-  * REST API:  POST /api/update  and  POST /api/update/all   (docs at /apidocs/)
+There is a new, thin CLI over the maintained core:
+  * python -m app.cli check      compare every device against the latest release
+  * python -m app.cli update     update every outdated device
+  * python -m app.cli list       list configured devices and their firmware
 
-See docs/cli-usage.md for details and migration notes.
+Other interfaces:
+  * Web UI:   python server.py   ->  http://localhost:5001
+  * REST API: POST /api/update, POST /api/update/all   (docs at /apidocs/)
+
+The options of the old CLI (-f/--file aside) do not carry over: --update-all,
+--check-only, --dry-run and --example are gone. See docs/cli-usage.md.
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -354,3 +354,98 @@ def test_run_batch_raises_on_runner_error(monkeypatch):
     )
     with pytest.raises(cli.CliError, match="boom"):
         cli.run_batch([{"ip": "1"}], check_only=True, timeout=None)
+
+
+def test_cmd_update_only_touches_outdated_devices(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
+        if check_only:
+            return [
+                _result(ip="1", needs_update=True),
+                _result(ip="2"),
+            ]
+        return [_result(ip="1", needs_update=True, update_completed=True, success=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+
+    results = cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)
+
+    assert passes[0] == {"ips": ["1", "2"], "check_only": True}
+    assert passes[1] == {"ips": ["1"], "check_only": False}
+    by_ip = {r["ip"]: r for r in results}
+    assert by_ip["1"]["update_completed"] is True
+    assert by_ip["2"].get("update_completed") is None
+    assert len(results) == 2
+
+
+def test_cmd_update_skips_the_second_pass_when_nothing_is_outdated(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append(check_only)
+        return [_result(ip="1")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+
+    assert passes == [True]
+    assert results == [_result(ip="1")]
+
+
+def test_cmd_update_does_not_flash_on_unknown_comparison(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append(check_only)
+        return [_result(ip="1", latest_version="Unknown")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+
+    assert passes == [True], "an unknown comparison must not trigger a flash"
+    assert cli.classify(results[0]) == "comparison_unknown"
+
+
+def test_cmd_update_force_updates_every_reachable_device(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
+        if check_only:
+            return [_result(ip="1"), _result(ip="2", success=False)]
+        return [_result(ip="1", update_completed=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=True, timeout=None)
+
+    assert passes[1] == {"ips": ["1"], "check_only": False}, "unreachable devices stay out"
+
+
+def test_cmd_update_passes_the_timeout_to_the_second_pass_only(monkeypatch):
+    seen = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        seen.append((check_only, timeout))
+        return [_result(ip="1", needs_update=True)] if check_only else [_result(ip="1")]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    cli.cmd_update([{"ip": "1"}], force=False, timeout=300)
+
+    assert seen == [(True, None), (False, 300)]
+
+
+def test_cmd_update_raises_when_the_flash_pass_drops_a_selected_device(monkeypatch):
+    def fake_run_batch(devices, *, check_only, timeout):
+        if check_only:
+            return [
+                _result(ip="1", needs_update=True),
+                _result(ip="2", needs_update=True),
+            ]
+        return [_result(ip="1", needs_update=True, update_completed=True, success=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+
+    with pytest.raises(cli.CliError, match="2"):
+        cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Unit tests for the thin CLI wrapper (app/cli.py)."""
 import json
+import re
 
 import pytest
 
@@ -447,5 +448,44 @@ def test_cmd_update_raises_when_the_flash_pass_drops_a_selected_device(monkeypat
 
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
 
-    with pytest.raises(cli.CliError, match="2"):
+    with pytest.raises(cli.CliError) as excinfo:
         cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)
+
+    message = str(excinfo.value)
+    assert re.search(r"no result for: 2$", message)
+    assert "1" not in message.split("no result for:")[1]
+
+
+def test_cmd_update_raises_without_calling_the_runner_when_the_whole_subset_is_unmapped(
+    monkeypatch,
+):
+    calls = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        calls.append(check_only)
+        return [_result(ip="1", needs_update=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+
+    # "9" is not a configured device, so the selected IP from pass one can
+    # never be mapped back to a device to flash — the subset is empty.
+    with pytest.raises(cli.CliError, match=r"no result for: 1$"):
+        cli.cmd_update([{"ip": "9"}], force=False, timeout=None)
+
+    assert calls == [True], "the flash pass must not run against an empty subset"
+
+
+def test_cmd_update_force_does_not_flash_a_device_with_unknown_comparison(monkeypatch):
+    passes = []
+
+    def fake_run_batch(devices, *, check_only, timeout):
+        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
+        if check_only:
+            return [_result(ip="1", latest_version="Unknown")]
+        return [_result(ip="1", update_completed=True)]
+
+    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
+    results = cli.cmd_update([{"ip": "1"}], force=True, timeout=None)
+
+    assert len(passes) == 1, "a device with an unknown comparison must never be flashed"
+    assert results == [_result(ip="1", latest_version="Unknown")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,9 +23,8 @@ def test_parser_accepts_each_command(command):
 
 
 def test_parser_accepts_update_options():
-    args = cli.build_parser().parse_args(["update", "--timeout", "300", "--force"])
+    args = cli.build_parser().parse_args(["update", "--timeout", "300"])
     assert args.timeout == 300
-    assert args.force is True
 
 
 def test_parser_accepts_shared_options_after_verb():
@@ -42,7 +41,7 @@ def test_parser_rejects_shared_options_before_verb():
 @pytest.mark.parametrize("command", ["check", "list"])
 def test_parser_rejects_update_options_on_other_commands(command):
     with pytest.raises(SystemExit):
-        cli.build_parser().parse_args([command, "--force"])
+        cli.build_parser().parse_args([command, "--timeout", "300"])
 
 
 def test_resolve_devices_file_prefers_explicit_path():
@@ -92,8 +91,27 @@ def test_classify_up_to_date():
     assert cli.classify(_result()) == "up_to_date"
 
 
-def test_classify_failure_wins_over_unknown():
-    assert cli.classify(_result(success=False, latest_version="Unknown")) == "failed"
+def test_classify_failure_wins_over_unknown_when_truly_unreachable():
+    """A device that never answered has no current_version either — that is
+    a real failure, not just a stalled comparison."""
+    result = _result(success=False, latest_version="Unknown", current_version="Unknown")
+    assert cli.classify(result) == "failed"
+
+
+def test_classify_release_lookup_failure_is_comparison_unknown_not_failed():
+    """success=False with a known current_version but an unknown
+    latest_version means the device answered fine — only the release lookup
+    (e.g. GitHub rate limit) failed. That must not read as unreachable (#91's
+    CLI twin, finding 2)."""
+    result = _result(success=False, current_version="14.6.0", latest_version="Unknown")
+    assert cli.classify(result) == "comparison_unknown"
+
+
+def test_classify_failed_update_with_known_latest_version_is_still_failed():
+    """A genuine flash failure carries a known latest_version — it must not
+    be reclassified as comparison_unknown just because success is False."""
+    result = _result(success=False, current_version="14.6.0", latest_version="15.0.1")
+    assert cli.classify(result) == "failed"
 
 
 def test_summarize_check_counts_every_class():
@@ -403,7 +421,7 @@ def test_cmd_update_only_touches_outdated_devices(monkeypatch):
 
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
 
-    results = cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)
+    results = cli.cmd_update([{"ip": "1"}, {"ip": "2"}], timeout=None)
 
     assert passes[0] == {"ips": ["1", "2"], "check_only": True}
     assert passes[1] == {"ips": ["1"], "check_only": False}
@@ -421,7 +439,7 @@ def test_cmd_update_skips_the_second_pass_when_nothing_is_outdated(monkeypatch):
         return [_result(ip="1")]
 
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
-    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+    results = cli.cmd_update([{"ip": "1"}], timeout=None)
 
     assert passes == [True]
     assert results == [_result(ip="1")]
@@ -435,25 +453,10 @@ def test_cmd_update_does_not_flash_on_unknown_comparison(monkeypatch):
         return [_result(ip="1", latest_version="Unknown")]
 
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
-    results = cli.cmd_update([{"ip": "1"}], force=False, timeout=None)
+    results = cli.cmd_update([{"ip": "1"}], timeout=None)
 
     assert passes == [True], "an unknown comparison must not trigger a flash"
     assert cli.classify(results[0]) == "comparison_unknown"
-
-
-def test_cmd_update_force_updates_every_reachable_device(monkeypatch):
-    passes = []
-
-    def fake_run_batch(devices, *, check_only, timeout):
-        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
-        if check_only:
-            return [_result(ip="1"), _result(ip="2", success=False)]
-        return [_result(ip="1", update_completed=True)]
-
-    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
-    cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=True, timeout=None)
-
-    assert passes[1] == {"ips": ["1"], "check_only": False}, "unreachable devices stay out"
 
 
 def test_cmd_update_passes_the_timeout_to_the_second_pass_only(monkeypatch):
@@ -464,7 +467,7 @@ def test_cmd_update_passes_the_timeout_to_the_second_pass_only(monkeypatch):
         return [_result(ip="1", needs_update=True)] if check_only else [_result(ip="1")]
 
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
-    cli.cmd_update([{"ip": "1"}], force=False, timeout=300)
+    cli.cmd_update([{"ip": "1"}], timeout=300)
 
     assert seen == [(True, None), (False, 300)]
 
@@ -481,11 +484,11 @@ def test_cmd_update_raises_when_the_flash_pass_drops_a_selected_device(monkeypat
     monkeypatch.setattr(cli, "run_batch", fake_run_batch)
 
     with pytest.raises(cli.CliError) as excinfo:
-        cli.cmd_update([{"ip": "1"}, {"ip": "2"}], force=False, timeout=None)
+        cli.cmd_update([{"ip": "1"}, {"ip": "2"}], timeout=None)
 
     message = str(excinfo.value)
-    assert re.search(r"no result for: 2$", message)
-    assert "1" not in message.split("no result for:")[1]
+    assert re.search(r"configuration for: 2$", message)
+    assert "1" not in message.split("configuration for:")[1]
 
 
 def test_cmd_update_raises_without_calling_the_runner_when_the_whole_subset_is_unmapped(
@@ -501,26 +504,10 @@ def test_cmd_update_raises_without_calling_the_runner_when_the_whole_subset_is_u
 
     # "9" is not a configured device, so the selected IP from pass one can
     # never be mapped back to a device to flash — the subset is empty.
-    with pytest.raises(cli.CliError, match=r"no result for: 1$"):
-        cli.cmd_update([{"ip": "9"}], force=False, timeout=None)
+    with pytest.raises(cli.CliError, match=r"configuration for: 1$"):
+        cli.cmd_update([{"ip": "9"}], timeout=None)
 
     assert calls == [True], "the flash pass must not run against an empty subset"
-
-
-def test_cmd_update_force_does_not_flash_a_device_with_unknown_comparison(monkeypatch):
-    passes = []
-
-    def fake_run_batch(devices, *, check_only, timeout):
-        passes.append({"ips": [d["ip"] for d in devices], "check_only": check_only})
-        if check_only:
-            return [_result(ip="1", latest_version="Unknown")]
-        return [_result(ip="1", update_completed=True)]
-
-    monkeypatch.setattr(cli, "run_batch", fake_run_batch)
-    results = cli.cmd_update([{"ip": "1"}], force=True, timeout=None)
-
-    assert len(passes) == 1, "a device with an unknown comparison must never be flashed"
-    assert results == [_result(ip="1", latest_version="Unknown")]
 
 
 def test_main_writes_only_json_to_stdout_at_debug_level(monkeypatch, capsys, tmp_path):
@@ -587,7 +574,7 @@ def test_main_handles_interrupt_and_warns_about_the_running_flash(monkeypatch, c
     devices_file = tmp_path / "devices.yaml"
     devices_file.write_text("devices:\n  - ip: 1\n", encoding="utf-8")
 
-    def interrupt(devices, *, force, timeout):
+    def interrupt(devices, *, timeout):
         raise KeyboardInterrupt
 
     monkeypatch.setattr(cli, "cmd_update", interrupt)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -267,6 +267,21 @@ def test_render_human_list_marks_unreachable():
     assert "nicht erreichbar" in text
 
 
+def test_render_human_keeps_columns_apart_when_dns_name_overruns_its_width():
+    """A long dns_name must not glue itself to the version column (regression)."""
+    results = [
+        {
+            "ip": "192.168.100.104",
+            "dns_name": "fake-tasmota-slow-device.local",
+            "success": True,
+            "current_version": "11.0.0",
+        }
+    ]
+    text = cli.render_human("list", results, cli.summarize(results, "list"))
+    assert "fake-tasmota-slow-device.local  11.0.0" in text
+    assert "local11.0.0" not in text
+
+
 def test_cmd_list_reports_firmware_without_release_lookup(monkeypatch):
     calls = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 """Unit tests for the thin CLI wrapper (app/cli.py)."""
+import json
+
 import pytest
 
 from app import cli
@@ -185,3 +187,56 @@ def test_exit_code_list_reports_unreachable_device():
 def test_exit_code_list_ignores_comparison():
     summary = cli.summarize([_result(latest_version="Unknown")], "list")
     assert cli.exit_code_for("list", summary) == cli.EXIT_OK
+
+
+def test_render_human_labels_each_class():
+    results = [
+        _result(ip="192.168.8.191", needs_update=True, dns_name="flur"),
+        _result(ip="192.168.8.192", dns_name="kueche"),
+        _result(ip="192.168.8.193", latest_version="Unknown", dns_name="bad"),
+        _result(ip="192.168.8.194", success=False, dns_name="keller"),
+    ]
+    text = cli.render_human("check", results, cli.summarize(results, "check"))
+    assert "192.168.8.191" in text
+    assert "Update verfügbar" in text
+    assert "aktuell" in text
+    assert "Vergleich unbekannt" in text
+    assert "nicht erreichbar" in text
+
+
+def test_render_human_uses_update_labels():
+    results = [
+        _result(ip="1", needs_update=True, update_completed=True),
+        _result(ip="2"),
+        _result(ip="3", success=False, update_started=True),
+    ]
+    text = cli.render_human("update", results, cli.summarize(results, "update"))
+    assert "aktualisiert" in text
+    assert "übersprungen" in text
+    assert "Update fehlgeschlagen" in text
+    assert "Update verfügbar" not in text
+
+
+def test_render_human_ends_with_the_tally():
+    results = [_result(needs_update=True)]
+    text = cli.render_human("check", results, cli.summarize(results, "check"))
+    assert text.splitlines()[-1] == "0 aktuell, 1 Update verfügbar, 0 Vergleich unbekannt, 0 Fehler"
+
+
+def test_render_json_is_parseable_and_complete():
+    results = [_result(needs_update=True)]
+    summary = cli.summarize(results, "check")
+    payload = json.loads(
+        cli.render_json("check", "devices.yaml", results, summary, cli.EXIT_OUTDATED)
+    )
+    assert payload["command"] == "check"
+    assert payload["devices_file"] == "devices.yaml"
+    assert payload["exit_code"] == cli.EXIT_OUTDATED
+    assert payload["summary"] == summary
+    assert payload["results"][0]["ip"] == "192.168.8.191"
+
+
+def test_render_json_passes_core_fields_through_unchanged():
+    results = [_result(message="anything the core said")]
+    payload = json.loads(cli.render_json("check", "d.yaml", results, {}, cli.EXIT_OK))
+    assert payload["results"][0]["message"] == "anything the core said"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,10 +12,10 @@ def test_parser_requires_a_command():
 
 @pytest.mark.parametrize("command", ["check", "update", "list"])
 def test_parser_accepts_each_command(command):
-    args = cli.build_parser().parse_args([command])
+    args = cli.build_parser().parse_args([command, "--json"])
     assert args.command == command
+    assert args.json is True
     assert args.file is None
-    assert args.json is False
     assert args.log_level == "WARNING"
 
 
@@ -23,6 +23,17 @@ def test_parser_accepts_update_options():
     args = cli.build_parser().parse_args(["update", "--timeout", "300", "--force"])
     assert args.timeout == 300
     assert args.force is True
+
+
+def test_parser_accepts_shared_options_after_verb():
+    args = cli.build_parser().parse_args(["check", "-f", "custom.yaml", "--log-level", "DEBUG"])
+    assert args.file == "custom.yaml"
+    assert args.log_level == "DEBUG"
+
+
+def test_parser_rejects_shared_options_before_verb():
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["--json", "check"])
 
 
 @pytest.mark.parametrize("command", ["check", "list"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -489,3 +489,77 @@ def test_cmd_update_force_does_not_flash_a_device_with_unknown_comparison(monkey
 
     assert len(passes) == 1, "a device with an unknown comparison must never be flashed"
     assert results == [_result(ip="1", latest_version="Unknown")]
+
+
+def test_main_writes_only_json_to_stdout_at_debug_level(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 192.168.8.191\n", encoding="utf-8")
+    monkeypatch.setattr(cli, "cmd_check", lambda devices: [_result()])
+
+    code = cli.main(["check", "-f", str(devices_file), "--json", "--log-level", "DEBUG"])
+
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_OK
+    assert json.loads(captured.out)["command"] == "check"
+
+
+def test_main_reports_missing_devices_file(monkeypatch, capsys, tmp_path):
+    code = cli.main(["check", "-f", str(tmp_path / "nope.yaml")])
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "nope.yaml" in captured.err
+
+
+def test_main_reports_empty_device_list(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices: []\n", encoding="utf-8")
+    code = cli.main(["check", "-f", str(devices_file)])
+    captured = capsys.readouterr()
+    assert code == cli.EXIT_ERROR
+    assert "No devices" in captured.err
+
+
+def test_main_rejects_duplicate_ips_before_touching_any_device(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text(
+        "devices:\n  - ip: 192.168.8.191\n  - ip: 192.168.8.191\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli, "cmd_update", lambda *a, **k: pytest.fail("must not be called")
+    )
+
+    code = cli.main(["update", "-f", str(devices_file)])
+    captured = capsys.readouterr()
+
+    assert code == cli.EXIT_ERROR
+    assert captured.out == ""
+    assert "192.168.8.191" in captured.err
+
+
+def test_main_turns_cli_errors_into_exit_two(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 1\n", encoding="utf-8")
+
+    def explode(devices):
+        raise cli.CliError("runner said no")
+
+    monkeypatch.setattr(cli, "cmd_check", explode)
+    code = cli.main(["check", "-f", str(devices_file)])
+    assert code == cli.EXIT_ERROR
+    assert "runner said no" in capsys.readouterr().err
+
+
+def test_main_handles_interrupt_and_warns_about_the_running_flash(monkeypatch, capsys, tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 1\n", encoding="utf-8")
+
+    def interrupt(devices, *, force, timeout):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "cmd_update", interrupt)
+    code = cli.main(["update", "-f", str(devices_file)])
+    err = capsys.readouterr().err
+    assert code == cli.EXIT_ERROR
+    assert "weiter" in err  # the flash keeps running on the device

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+"""Unit tests for the thin CLI wrapper (app/cli.py)."""
+import pytest
+
+from app import cli
+
+
+def test_parser_requires_a_command():
+    parser = cli.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+@pytest.mark.parametrize("command", ["check", "update", "list"])
+def test_parser_accepts_each_command(command):
+    args = cli.build_parser().parse_args([command])
+    assert args.command == command
+    assert args.file is None
+    assert args.json is False
+    assert args.log_level == "WARNING"
+
+
+def test_parser_accepts_update_options():
+    args = cli.build_parser().parse_args(["update", "--timeout", "300", "--force"])
+    assert args.timeout == 300
+    assert args.force is True
+
+
+@pytest.mark.parametrize("command", ["check", "list"])
+def test_parser_rejects_update_options_on_other_commands(command):
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args([command, "--force"])
+
+
+def test_resolve_devices_file_prefers_explicit_path():
+    assert cli.resolve_devices_file("custom.yaml", {"DEVICES_FILE": "env.yaml"}) == "custom.yaml"
+
+
+def test_resolve_devices_file_falls_back_to_environment():
+    assert cli.resolve_devices_file(None, {"DEVICES_FILE": "env.yaml"}) == "env.yaml"
+
+
+def test_resolve_devices_file_defaults_to_devices_yaml():
+    assert cli.resolve_devices_file(None, {}) == "devices.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,3 +52,92 @@ def test_resolve_devices_file_falls_back_to_environment():
 
 def test_resolve_devices_file_defaults_to_devices_yaml():
     assert cli.resolve_devices_file(None, {}) == "devices.yaml"
+
+
+def _result(**overrides):
+    base = {
+        "ip": "192.168.8.191",
+        "success": True,
+        "current_version": "14.6.0",
+        "latest_version": "15.0.1",
+        "needs_update": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_classify_failed_device():
+    assert cli.classify(_result(success=False)) == "failed"
+
+
+@pytest.mark.parametrize("latest", ["Unknown", "", None])
+def test_classify_unknown_comparison(latest):
+    assert cli.classify(_result(latest_version=latest)) == "comparison_unknown"
+
+
+def test_classify_missing_latest_version_is_unknown():
+    result = _result()
+    del result["latest_version"]
+    assert cli.classify(result) == "comparison_unknown"
+
+
+def test_classify_needs_update():
+    assert cli.classify(_result(needs_update=True)) == "needs_update"
+
+
+def test_classify_up_to_date():
+    assert cli.classify(_result()) == "up_to_date"
+
+
+def test_classify_failure_wins_over_unknown():
+    assert cli.classify(_result(success=False, latest_version="Unknown")) == "failed"
+
+
+def test_summarize_check_counts_every_class():
+    results = [
+        _result(ip="1", needs_update=True),
+        _result(ip="2"),
+        _result(ip="3", latest_version="Unknown"),
+        _result(ip="4", success=False),
+    ]
+    assert cli.summarize(results, "check") == {
+        "total": 4,
+        "up_to_date": 1,
+        "needs_update": 1,
+        "comparison_unknown": 1,
+        "failed": 1,
+    }
+
+
+def test_summarize_list_only_counts_failures():
+    results = [_result(ip="1"), _result(ip="2", success=False)]
+    assert cli.summarize(results, "list") == {"total": 2, "failed": 1}
+
+
+def test_summarize_update_counts_updated_and_skipped():
+    results = [
+        _result(ip="1", needs_update=True, update_completed=True),
+        _result(ip="2"),
+        _result(ip="3", success=False, update_started=True),
+        _result(ip="4", latest_version="Unknown"),
+    ]
+    assert cli.summarize(results, "update") == {
+        "total": 4,
+        "updated": 1,
+        "skipped": 1,
+        "comparison_unknown": 1,
+        "failed": 1,
+    }
+
+
+def test_summarize_update_does_not_count_an_updated_device_as_skipped():
+    """After a successful update the device reports the new version, so it
+    classifies as up_to_date — it must not land in both buckets."""
+    results = [_result(ip="1", needs_update=False, update_completed=True)]
+    assert cli.summarize(results, "update") == {
+        "total": 1,
+        "updated": 1,
+        "skipped": 0,
+        "comparison_unknown": 0,
+        "failed": 0,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,6 +282,23 @@ def test_render_human_keeps_columns_apart_when_dns_name_overruns_its_width():
     assert "local11.0.0" not in text
 
 
+def test_render_human_keeps_label_apart_when_version_column_overruns():
+    """A version column wider than its fixed width must not glue itself to the
+    label that follows it (regression: the fix for the dns_name/version gap
+    above did not cover the version/label gap)."""
+    results = [
+        _result(
+            ip="192.168.100.103",
+            dns_name="fake-tasmota-plug1.local",
+            current_version="12.0.2(tasmota-minimal)",
+            needs_update=True,
+        )
+    ]
+    text = cli.render_human("check", results, cli.summarize(results, "check"))
+    assert "12.0.2(tasmota-minimal) → 15.0.1  Update verfügbar" in text
+    assert "15.0.1Update verfügbar" not in text
+
+
 def test_cmd_list_reports_firmware_without_release_lookup(monkeypatch):
     calls = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,3 +264,36 @@ def test_render_human_list_marks_unreachable():
     results = [{"ip": "192.168.8.192", "success": False, "current_version": "14.0.0"}]
     text = cli.render_human("list", results, cli.summarize(results, "list"))
     assert "nicht erreichbar" in text
+
+
+def test_cmd_list_reports_firmware_without_release_lookup(monkeypatch):
+    calls = []
+
+    def fake_firmware(device):
+        calls.append(device["ip"])
+        return {"version": "15.0.1", "core_version": "2.7.4.9"}
+
+    def explode():  # must never be called
+        raise AssertionError("list must not perform a release lookup")
+
+    monkeypatch.setattr(cli.updater, "get_device_firmware_version", fake_firmware)
+    monkeypatch.setattr(cli.updater, "fetch_latest_tasmota_release", explode)
+
+    devices = [{"ip": "192.168.8.191", "dns_name": "flur"}, {"ip": "192.168.8.192"}]
+    results = cli.cmd_list(devices)
+
+    assert calls == ["192.168.8.191", "192.168.8.192"]
+    assert results[0] == {
+        "ip": "192.168.8.191",
+        "dns_name": "flur",
+        "success": True,
+        "current_version": "15.0.1",
+    }
+    assert "latest_version" not in results[0]
+
+
+def test_cmd_list_marks_unreachable_device(monkeypatch):
+    monkeypatch.setattr(cli.updater, "get_device_firmware_version", lambda device: None)
+    results = cli.cmd_list([{"ip": "192.168.8.193"}])
+    assert results[0]["success"] is False
+    assert results[0]["current_version"] == "Unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,3 +240,27 @@ def test_render_json_passes_core_fields_through_unchanged():
     results = [_result(message="anything the core said")]
     payload = json.loads(cli.render_json("check", "d.yaml", results, {}, cli.EXIT_OK))
     assert payload["results"][0]["message"] == "anything the core said"
+
+
+def test_render_human_list_no_comparison_wording():
+    """list performs no release lookup, so comparison labels must not appear."""
+    results = [
+        {
+            "ip": "192.168.8.191",
+            "dns_name": "flur",
+            "success": True,
+            "current_version": "15.0.1",
+        }
+    ]
+    text = cli.render_human("list", results, cli.summarize(results, "list"))
+    assert "Vergleich unbekannt" not in text
+    assert "aktuell" not in text
+    assert "15.0.1" in text
+    assert "192.168.8.191" in text
+
+
+def test_render_human_list_marks_unreachable():
+    """list marks unreachable devices with nicht erreichbar."""
+    results = [{"ip": "192.168.8.192", "success": False, "current_version": "14.0.0"}]
+    text = cli.render_human("list", results, cli.summarize(results, "list"))
+    assert "nicht erreichbar" in text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,3 +141,47 @@ def test_summarize_update_does_not_count_an_updated_device_as_skipped():
         "comparison_unknown": 0,
         "failed": 0,
     }
+
+
+def test_exit_code_ok_when_everything_current():
+    summary = cli.summarize([_result()], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_OK
+
+
+def test_exit_code_outdated_for_check():
+    summary = cli.summarize([_result(needs_update=True)], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_OUTDATED
+
+
+def test_exit_code_error_on_unknown_comparison():
+    summary = cli.summarize([_result(latest_version="Unknown")], "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_error_beats_outdated():
+    results = [_result(ip="1", needs_update=True), _result(ip="2", success=False)]
+    summary = cli.summarize(results, "check")
+    assert cli.exit_code_for("check", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_update_never_returns_one():
+    """A device that was just updated still carries needs_update from before."""
+    results = [_result(needs_update=True, update_completed=True)]
+    summary = cli.summarize(results, "update")
+    assert cli.exit_code_for("update", summary) == cli.EXIT_OK
+
+
+def test_exit_code_update_reports_failure():
+    results = [_result(success=False, update_started=True)]
+    summary = cli.summarize(results, "update")
+    assert cli.exit_code_for("update", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_list_reports_unreachable_device():
+    summary = cli.summarize([_result(success=False)], "list")
+    assert cli.exit_code_for("list", summary) == cli.EXIT_ERROR
+
+
+def test_exit_code_list_ignores_comparison():
+    summary = cli.summarize([_result(latest_version="Unknown")], "list")
+    assert cli.exit_code_for("list", summary) == cli.EXIT_OK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,3 +308,49 @@ def test_cmd_list_treats_a_versionless_answer_as_a_failure(monkeypatch):
     results = cli.cmd_list([{"ip": "192.168.8.194"}])
     assert results[0]["success"] is False
     assert results[0]["current_version"] == "Unknown"
+
+
+def test_cmd_check_delegates_to_the_batch_runner(monkeypatch):
+    seen = {}
+
+    def fake_create(devices, check_only, update_only_needed, global_timeout, **kwargs):
+        seen.update(
+            devices=list(devices),
+            check_only=check_only,
+            update_only_needed=update_only_needed,
+            global_timeout=global_timeout,
+            background=kwargs.get("background"),
+        )
+        return "job-1"
+
+    monkeypatch.setattr(cli.jobs, "create_batch_job", fake_create)
+    monkeypatch.setattr(
+        cli.jobs,
+        "get_job",
+        lambda job_id: {"status": "completed", "results": [_result()], "error": None},
+    )
+
+    results = cli.cmd_check([{"ip": "192.168.8.191"}])
+
+    assert seen["check_only"] is True
+    assert seen["update_only_needed"] is False
+    assert seen["global_timeout"] is None
+    assert seen["background"] is False
+    assert results == [_result()]
+
+
+def test_run_batch_raises_when_the_runner_refuses(monkeypatch):
+    monkeypatch.setattr(cli.jobs, "create_batch_job", lambda *a, **k: None)
+    with pytest.raises(cli.CliError, match="batch job"):
+        cli.run_batch([{"ip": "1"}], check_only=True, timeout=None)
+
+
+def test_run_batch_raises_on_runner_error(monkeypatch):
+    monkeypatch.setattr(cli.jobs, "create_batch_job", lambda *a, **k: "job-1")
+    monkeypatch.setattr(
+        cli.jobs,
+        "get_job",
+        lambda job_id: {"status": "error", "results": [], "error": "boom"},
+    )
+    with pytest.raises(cli.CliError, match="boom"):
+        cli.run_batch([{"ip": "1"}], check_only=True, timeout=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,3 +297,14 @@ def test_cmd_list_marks_unreachable_device(monkeypatch):
     results = cli.cmd_list([{"ip": "192.168.8.193"}])
     assert results[0]["success"] is False
     assert results[0]["current_version"] == "Unknown"
+
+
+def test_cmd_list_treats_a_versionless_answer_as_a_failure(monkeypatch):
+    monkeypatch.setattr(
+        cli.updater,
+        "get_device_firmware_version",
+        lambda device: {"core_version": "2.7.4.9"},  # no "version" key
+    )
+    results = cli.cmd_list([{"ip": "192.168.8.194"}])
+    assert results[0]["success"] is False
+    assert results[0]["current_version"] == "Unknown"

--- a/tests/test_cli_deprecated.py
+++ b/tests/test_cli_deprecated.py
@@ -1,4 +1,5 @@
-"""The CLI is deprecated (Phase 4): it must only print a notice and exit non-zero."""
+"""The old CLI is retired (Phase 4): it must only print a notice pointing at the
+new one and exit non-zero."""
 import subprocess
 import sys
 from pathlib import Path
@@ -15,6 +16,6 @@ def test_cli_prints_deprecation_and_exits_nonzero():
         timeout=30,
     )
     assert result.returncode == 1
-    assert "deprecated" in result.stderr.lower()
+    assert "python -m app.cli" in result.stderr
     # It must not fall through into the old (broken) logic.
     assert "Traceback" not in result.stderr

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,48 @@
+"""End-to-end smoke test: run the CLI as a subprocess against fake devices."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run(command, *args):
+    return subprocess.run(
+        [sys.executable, "-m", "app.cli", command, "-f", "devices-dev.yaml", *args],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_list_json_reports_every_fake_device():
+    result = _run("list", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "list"
+    assert payload["summary"]["total"] >= 1
+    assert payload["summary"]["failed"] == 0
+    assert all("latest_version" not in entry for entry in payload["results"])
+
+
+def test_check_json_is_parseable_whatever_the_release_lookup_does():
+    result = _run("check", "--json")
+    assert result.returncode in (0, 1, 2), result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "check"
+    assert payload["exit_code"] == result.returncode
+    assert set(payload["summary"]) == {
+        "total",
+        "up_to_date",
+        "needs_update",
+        "comparison_unknown",
+        "failed",
+    }
+
+
+def test_human_output_ends_with_a_tally():
+    result = _run("list")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[-1].endswith("Fehler")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -2,9 +2,56 @@
 import json
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
+import pytest
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DEVICES_FILE = REPO_ROOT / "devices-dev.yaml"
+
+# Matches the shape updater.save_to_cache()/get_cached_data() use for the
+# 'latest_release' cache — see app/tasmota/updater.py. Pre-seeding it makes
+# `check` deterministic without touching production code: no live,
+# unauthenticated GitHub call inside the required pytest job (see #76 —
+# exactly this kind of live dependency is what makes CI flaky).
+CACHE_FILE = REPO_ROOT / "app" / "tasmota" / "cache" / "latest_release.json"
+STUBBED_LATEST_VERSION = "99.0.0"  # newer than every fake device in devices-dev.yaml
+STUBBED_RELEASE = {
+    "version": STUBBED_LATEST_VERSION,
+    "release_date": "2026-01-01T00:00:00Z",
+    "release_notes": "stubbed for test_cli_smoke",
+    "download_url": "https://example.invalid/tasmota.bin",
+    "release_url": "https://github.com/arendst/Tasmota/releases/",
+}
+
+
+@pytest.fixture
+def stubbed_release_cache():
+    """Pre-seed the release cache so `check` never calls GitHub.
+
+    Backs up and restores whatever cache file the developer already has, so
+    running this test does not leave their own cache modified.
+    """
+    original = CACHE_FILE.read_bytes() if CACHE_FILE.exists() else None
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_FILE.write_text(
+        json.dumps({"cache_timestamp": datetime.now().isoformat(), "data": STUBBED_RELEASE})
+    )
+    try:
+        yield
+    finally:
+        if original is None:
+            CACHE_FILE.unlink(missing_ok=True)
+        else:
+            CACHE_FILE.write_bytes(original)
+
+
+def _configured_device_count() -> int:
+    with DEVICES_FILE.open(encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+    return len(config["devices"])
 
 
 def _run(command, *args):
@@ -22,24 +69,31 @@ def test_list_json_reports_every_fake_device():
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["command"] == "list"
-    assert payload["summary"]["total"] >= 1
+    # A dropped device must not slip past a loose ">= 1" — every configured
+    # device must show up (finding 4: a silently shrunk devices-dev.yaml
+    # would still pass a ">= 1" check).
+    assert payload["summary"]["total"] == _configured_device_count()
     assert payload["summary"]["failed"] == 0
     assert all("latest_version" not in entry for entry in payload["results"])
 
 
-def test_check_json_is_parseable_whatever_the_release_lookup_does():
+def test_check_json_is_parseable_with_a_stubbed_release_lookup(stubbed_release_cache):
     result = _run("check", "--json")
-    assert result.returncode in (0, 1, 2), result.stderr
     payload = json.loads(result.stdout)
+    device_count = _configured_device_count()
+    # Every fake device in devices-dev.yaml is older than STUBBED_LATEST_VERSION,
+    # so the outcome — and therefore the exit code — is now deterministic.
+    assert result.returncode == 1, result.stderr
     assert payload["command"] == "check"
-    assert payload["exit_code"] == result.returncode
-    assert set(payload["summary"]) == {
-        "total",
-        "up_to_date",
-        "needs_update",
-        "comparison_unknown",
-        "failed",
+    assert payload["exit_code"] == 1
+    assert payload["summary"] == {
+        "total": device_count,
+        "up_to_date": 0,
+        "needs_update": device_count,
+        "comparison_unknown": 0,
+        "failed": 0,
     }
+    assert all(r["latest_version"] == STUBBED_LATEST_VERSION for r in payload["results"])
 
 
 def test_human_output_ends_with_a_tally():


### PR DESCRIPTION
Setzt den Backlog-Eintrag aus Phase 4 des Audits um: eine **dünne** CLI über dem gepflegten Kern in `app/tasmota` — kein zweiter Ausführungspfad, keine Kopie der Update-Logik. Genau diese Duplikation (~900 Zeilen, davongelaufen) hat die alte CLI gekostet.

```bash
python -m app.cli check            # jedes Gerät gegen das aktuelle Release vergleichen
python -m app.cli update           # veraltete Geräte aktualisieren
python -m app.cli list --json      # Inventar, ohne Release-Lookup
```

Design und Plan liegen im PR: [`2026-07-28-cli-design.md`](docs/audit-2026-07/2026-07-28-cli-design.md), [`2026-07-28-cli-plan.md`](docs/audit-2026-07/2026-07-28-cli-plan.md).

## Der Vertrag für cron

Exit-Codes, nicht Textparsing: `0` alles aktuell · `1` mindestens ein Gerät veraltet (nur `check`) · `2` Fehler. Bei gemischten Ergebnissen gewinnt der höhere Code.

```bash
python -m app.cli check || mail -s "Tasmota veraltet" me@example.com
```

Gemessen, nicht behauptet: `check` gegen die veralteten Fake-Geräte → 1, `list` → 0, fehlende Datei → 2.

**Die Regel, um die herum das Ganze gebaut ist:** ein fehlgeschlagener Release-Lookup ist ein *Fehler*, niemals „aktuell". Das ist #91 eine Ebene tiefer — und in einem cron-Job folgenschwerer, weil er dann einfach dauerhaft schweigt.

## Was die Reviews gefunden haben

Zehn Tasks, jeder mit eigenem Review; sechs brauchten eine Fix-Runde. Die drei, die es wert sind, genannt zu werden:

- **`--force` flashte nichts und meldete Erfolg.** `update_device_firmware()` hat keinen `force`-Parameter und kehrt bei aktueller Version früh mit `success=True` zurück; der Batch-Runner stempelt daraufhin `update_completed`, die CLI schrieb `aktualisiert` und Exit 0 für ein Gerät, das sie nie angefasst hat. Alle `--force`-Tests hatten `run_batch` gemockt und sich das Ergebnis selbst hineingereicht. **`--force` ist deshalb aus diesem PR entfernt** — die Kern-Erweiterung ist #126, samt der Falle, dass `verify_firmware_version_changed()` beim Reflash auf dieselbe Version keine Änderung sieht.
- **Ein GitHub-Rate-Limit meldete jedes Gerät als „nicht erreichbar"** und schickte den Betreiber ins LAN suchen. Jetzt `Vergleich unbekannt` — der Exit-Code war vorher schon richtig, die Diagnose nicht.
- **`success: True` bei `current_version: "Unknown"`** war möglich (Fake-Gerät mit unvollständigem `firmware_info`). Dieselbe Unehrlichkeit wie #91, eine Ebene versetzt.

## Warum `update` zwei Pässe fährt

Der Filter `update_only_needed` des Runners lässt übersprungene Geräte **komplett aus den Ergebnissen fallen**. Ein Gerät, das wegen gescheitertem Vergleich übersprungen wird, verschwände damit spurlos — ein kaputter Lookup sähe aus wie „alles aktuell". Die CLI klassifiziert deshalb erst selbst und flasht dann nur die ausgewählte Teilmenge. Liefert der Flash-Pass für ein ausgewähltes Gerät kein Ergebnis, bricht sie mit Exit 2 ab, statt still die alte Zeile zu behalten.

## Tests

139 im grünen Kern (+90 gegenüber vorher), plus ein Subprozess-Smoke-Test gegen die Fake-Geräte. Der Release-Lookup ist dort über den Cache gestubbt und die Fixture stellt den Entwickler-Cache im `finally` wieder her — der grüne Kern ruft GitHub nicht live auf (#76).

## Nicht abgedeckt

**`update` gegen echte Hardware ist unverifiziert.** Fake-Geräte bilden das OTA-Flash-Fenster nicht ab; das ist dieselbe Lücke wie bei #87 und lässt sich in CI nicht schließen. Ein Lauf gegen ein echtes Gerät bleibt der offene Gegentest.
