### PR TITLE
feat(editor): manage devices from the web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ compose.yml
 # Flask stuff:
 instance/
 .webassets-cache
+
+# Superpowers SDD scratch workspace
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ app/tasmota/cache/
 .env
 .env.local
 devices.yaml
+*.yaml.bak
 compose.yml
 
 # IDE specific files

--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,8 @@ ENV PATH="/opt/venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     HOST=0.0.0.0 \
-    PORT=5001
+    PORT=5001 \
+    DEVICES_FILE=/app/config/devices.yaml
 
 # Copy only necessary application files
 COPY server.py wsgi.py gunicorn.conf.py /app/

--- a/README.md
+++ b/README.md
@@ -67,18 +67,25 @@ docker pull ghcr.io/dodjango/tasmota-updater:latest
 
 # Run with Docker
 docker run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater dodjango/tasmota-updater:latest
 
 # OR run with Podman
 podman run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater dodjango/tasmota-updater:latest
 ```
 
 Then visit http://localhost:5001 in your browser.
+
+> **Migrating from an older version?** If you used to bind-mount
+> `devices.yaml` directly (`-v $(pwd)/devices.yaml:/app/devices.yaml`), that
+> still works, but the web UI's device editor stays read-only — replacing a
+> bind-mounted *file* fails with `EBUSY`. Move `devices.yaml` into a directory
+> (e.g. `./config/devices.yaml`) and mount that directory instead, as shown
+> above, to make the editor writable.
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Then visit http://localhost:5001 in your browser.
 > still works, but the web UI's device editor stays read-only — replacing a
 > bind-mounted *file* fails with `EBUSY`. Move `devices.yaml` into a directory
 > (e.g. `./config/devices.yaml`) and mount that directory instead, as shown
-> above, to make the editor writable.
+> above, to make the editor writable. The image already looks for the file at
+> `/app/config/devices.yaml` by default, so mounting `./config` there — as
+> the examples above do — is all that's needed; only set `DEVICES_FILE`
+> yourself if you use a different path inside the container.
 
 ## 📚 Documentation
 

--- a/app/static/js/devices-editor.js
+++ b/app/static/js/devices-editor.js
@@ -34,7 +34,7 @@ function devicesEditor() {
                 this.writable = payload.writable;
                 this.devicesFile = payload.devices_file;
             } catch (err) {
-                this.error = `Konfiguration konnte nicht geladen werden: ${err.message}`;
+                this.error = `Could not load the configuration: ${err.message}`;
             } finally {
                 this.loading = false;
             }
@@ -49,12 +49,14 @@ function devicesEditor() {
 
         removeDevice(index) {
             const device = this.devices[index];
-            const label = device.dns_name || device.ip || 'dieses Gerät';
-            if (!confirm(`${label} aus der Konfiguration entfernen?`)) return;
+            const label = device.dns_name || device.ip || 'this device';
+            if (!confirm(`Remove ${label} from the configuration?`)) return;
             this.devices.splice(index, 1);
         },
 
         clearPassword(device) {
+            const label = device.dns_name || device.ip || 'this device';
+            if (!confirm(`Remove the stored password for ${label}? It will be contacted without credentials until a new password is entered and saved.`)) return;
             device.remove_password = true;
             device.password = '';
             device.has_password = false;
@@ -63,8 +65,10 @@ function devicesEditor() {
         _payload() {
             return this.devices.map(device => {
                 const entry = { ip: (device.ip || '').trim() };
-                if (device.username) entry.username = device.username;
-                if (device.dns_name) entry.dns_name = device.dns_name;
+                const username = (device.username || '').trim();
+                const dnsName = (device.dns_name || '').trim();
+                if (username) entry.username = username;
+                if (dnsName) entry.dns_name = dnsName;
                 if (device.timeout) entry.timeout = Number(device.timeout);
                 if (device.password) entry.password = device.password;
                 if (device.remove_password) entry.remove_password = true;
@@ -84,7 +88,16 @@ function devicesEditor() {
                 });
                 const payload = await response.json();
                 if (!response.ok) {
-                    throw new Error(payload.details || `HTTP ${response.status}`);
+                    const message = payload.details || `HTTP ${response.status}`;
+                    if (response.status === 409) {
+                        // Not writable (or unreadable) — re-derive `writable` from the
+                        // server instead of letting the user retry against a file that
+                        // will keep rejecting. load() clears `error`, so re-apply it.
+                        await this.load();
+                        this.error = `Save failed: ${message}`;
+                        return;
+                    }
+                    throw new Error(message);
                 }
                 this.devices = payload.devices.map(device => ({
                     ...device, password: '', remove_password: false,
@@ -92,7 +105,7 @@ function devicesEditor() {
                 this.saved = true;
                 setTimeout(() => { this.saved = false; }, 4000);
             } catch (err) {
-                this.error = `Speichern fehlgeschlagen: ${err.message}`;
+                this.error = `Save failed: ${err.message}`;
             } finally {
                 this.saving = false;
             }

--- a/app/static/js/devices-editor.js
+++ b/app/static/js/devices-editor.js
@@ -14,6 +14,15 @@ function devicesEditor() {
         saving: false,
         error: '',
         saved: false,
+        // Only a successful GET may set this true. Save is gated on it so a
+        // failed load (expired session, proxy hiccup, 500) shows an empty,
+        // disabled table instead of an empty, saveable one — a Save click
+        // against that would submit `{devices: []}`, which is a perfectly
+        // legal request, and wipe the real configuration on disk.
+        loaded: false,
+        // The last successfully loaded device count, so save() can tell "the
+        // user really emptied the list" apart from "the list was never loaded".
+        loadedDeviceCount: 0,
 
         async init() {
             await this.load();
@@ -33,8 +42,11 @@ function devicesEditor() {
                 }));
                 this.writable = payload.writable;
                 this.devicesFile = payload.devices_file;
+                this.loadedDeviceCount = this.devices.length;
+                this.loaded = true;
             } catch (err) {
                 this.error = `Could not load the configuration: ${err.message}`;
+                this.loaded = false;
             } finally {
                 this.loading = false;
             }
@@ -77,6 +89,15 @@ function devicesEditor() {
         },
 
         async save() {
+            const submitted = this._payload();
+            if (submitted.length === 0 && this.loadedDeviceCount > 0) {
+                const confirmed = confirm(
+                    `This removes all ${this.loadedDeviceCount} device(s) from the ` +
+                    'configuration. Continue?'
+                );
+                if (!confirmed) return;
+            }
+
             this.saving = true;
             this.error = '';
             this.saved = false;
@@ -84,7 +105,7 @@ function devicesEditor() {
                 const response = await fetch('/api/config/devices', {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ devices: this._payload() }),
+                    body: JSON.stringify({ devices: submitted }),
                 });
                 const payload = await response.json();
                 if (!response.ok) {
@@ -102,7 +123,11 @@ function devicesEditor() {
                 this.devices = payload.devices.map(device => ({
                     ...device, password: '', remove_password: false,
                 }));
+                this.loadedDeviceCount = this.devices.length;
                 this.saved = true;
+                // Tell the operational device list (the cards above) to
+                // refresh — otherwise it keeps showing the pre-save devices.
+                this.$dispatch('devices-changed');
                 setTimeout(() => { this.saved = false; }, 4000);
             } catch (err) {
                 this.error = `Save failed: ${err.message}`;

--- a/app/static/js/devices-editor.js
+++ b/app/static/js/devices-editor.js
@@ -1,0 +1,101 @@
+/**
+ * Devices editor — edits the configuration behind /api/config/devices.
+ *
+ * The password is write-only: the server never sends it, an empty field means
+ * "keep", and removal is explicit. Changing a device's IP makes it a new device,
+ * so its password cannot follow.
+ */
+function devicesEditor() {
+    return {
+        devices: [],
+        writable: true,
+        devicesFile: '',
+        loading: false,
+        saving: false,
+        error: '',
+        saved: false,
+
+        async init() {
+            await this.load();
+        },
+
+        async load() {
+            this.loading = true;
+            this.error = '';
+            try {
+                const response = await fetch('/api/config/devices');
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const payload = await response.json();
+                this.devices = payload.devices.map(device => ({
+                    ...device,
+                    password: '',
+                    remove_password: false,
+                }));
+                this.writable = payload.writable;
+                this.devicesFile = payload.devices_file;
+            } catch (err) {
+                this.error = `Konfiguration konnte nicht geladen werden: ${err.message}`;
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        addDevice() {
+            this.devices.push({
+                ip: '', username: '', dns_name: '', timeout: null,
+                password: '', has_password: false, remove_password: false,
+            });
+        },
+
+        removeDevice(index) {
+            const device = this.devices[index];
+            const label = device.dns_name || device.ip || 'dieses Gerät';
+            if (!confirm(`${label} aus der Konfiguration entfernen?`)) return;
+            this.devices.splice(index, 1);
+        },
+
+        clearPassword(device) {
+            device.remove_password = true;
+            device.password = '';
+            device.has_password = false;
+        },
+
+        _payload() {
+            return this.devices.map(device => {
+                const entry = { ip: (device.ip || '').trim() };
+                if (device.username) entry.username = device.username;
+                if (device.dns_name) entry.dns_name = device.dns_name;
+                if (device.timeout) entry.timeout = Number(device.timeout);
+                if (device.password) entry.password = device.password;
+                if (device.remove_password) entry.remove_password = true;
+                return entry;
+            });
+        },
+
+        async save() {
+            this.saving = true;
+            this.error = '';
+            this.saved = false;
+            try {
+                const response = await fetch('/api/config/devices', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ devices: this._payload() }),
+                });
+                const payload = await response.json();
+                if (!response.ok) {
+                    throw new Error(payload.details || `HTTP ${response.status}`);
+                }
+                this.devices = payload.devices.map(device => ({
+                    ...device, password: '', remove_password: false,
+                }));
+                this.saved = true;
+                setTimeout(() => { this.saved = false; }, 4000);
+            } catch (err) {
+                this.error = `Speichern fehlgeschlagen: ${err.message}`;
+            } finally {
+                this.saving = false;
+            }
+        },
+    };
+}

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -105,7 +105,7 @@ class DeviceConfigResource(Resource):
 
         exposed = []
         for device in devices:
-            entry = {
+            entry: dict[str, Any] = {
                 field: device[field]
                 for field in ("ip", "username", "dns_name", "timeout")
                 if field in device

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -1,9 +1,10 @@
 """API endpoints for the Tasmota updater web application"""
 
 import os
+from typing import Any
 from flask import request, jsonify, current_app
 from flask_restful import Api, Resource
-from marshmallow import Schema, fields, validate
+from marshmallow import Schema, ValidationError, fields, validate
 from flasgger import swag_from
 from app.tasmota.updater import (
     get_device_firmware_version,
@@ -36,6 +37,47 @@ class DeviceUpdateSchema(Schema):
 
     class Meta:
         fields = ("ip", "username", "password", "check_only", "timeout")
+
+
+def _validate_device_ip(value: str) -> None:
+    """Reject anything is_valid_ip_address() rejects.
+
+    That function deliberately blocks loopback, link-local and the cloud
+    metadata address — the same block that keeps the update endpoints from
+    being turned into an SSRF primitive. The editor must not be a way around it.
+    """
+    if not is_valid_ip_address(value):
+        raise ValidationError(f"Not a usable device address: {value!r}")
+
+
+class DeviceConfigSchema(Schema):
+    """One device as the editor may submit it.
+
+    ``unknown = "raise"`` is a security property, not a convenience: it is
+    what keeps ``fake`` and ``firmware_info`` unsettable through the editor.
+    """
+
+    ip = fields.String(required=True, validate=_validate_device_ip)
+    username = fields.String()
+    password = fields.String()
+    dns_name = fields.String()
+    timeout = fields.Integer(validate=validate.Range(min=60, max=600))
+    remove_password = fields.Boolean()
+
+    class Meta:
+        unknown = "raise"
+
+
+def validate_device_list(devices: list[dict[str, Any]]) -> list[str]:
+    """List-level checks that a per-device schema cannot express."""
+    errors: list[str] = []
+    seen: set[Any] = set()
+    for device in devices:
+        ip = device.get("ip")
+        if ip in seen:
+            errors.append(f"Duplicate device address: {ip}")
+        seen.add(ip)
+    return errors
 
 
 # API Resources

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -1,6 +1,7 @@
 """API endpoints for the Tasmota updater web application"""
 
 import os
+from pathlib import Path
 from typing import Any
 from flask import request, jsonify, current_app
 from flask_restful import Api, Resource
@@ -13,6 +14,7 @@ from app.tasmota.updater import (
     is_valid_ip_address,
 )
 from app.tasmota.utils import load_devices_from_file, resolve_dns_name, is_fake_device
+from app.tasmota import device_config
 from app.tasmota import jobs
 
 
@@ -78,6 +80,44 @@ def validate_device_list(devices: list[dict[str, Any]]) -> list[str]:
             errors.append(f"Duplicate device address: {ip}")
         seen.add(ip)
     return errors
+
+
+class DeviceConfigResource(Resource):
+    """The device list as configuration — raw fields, editable.
+
+    Separate from DeviceListResource on purpose: that one is the operational
+    view and enriches its answer (masked password, resolved dns_name falling
+    back to the IP), which must never be written back to the file.
+    """
+
+    def get(self):
+        """
+        Get the raw device configuration
+        ---
+        tags:
+          - configuration
+        responses:
+          200:
+            description: Configured devices, passwords replaced by has_password
+        """
+        devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
+        devices = load_devices_from_file(str(devices_file))
+
+        exposed = []
+        for device in devices:
+            entry = {
+                field: device[field]
+                for field in ("ip", "username", "dns_name", "timeout")
+                if field in device
+            }
+            entry["has_password"] = bool(device.get("password"))
+            exposed.append(entry)
+
+        return jsonify({
+            "devices": exposed,
+            "writable": device_config.is_writable(devices_file),
+            "devices_file": str(devices_file),
+        })
 
 
 # API Resources
@@ -547,6 +587,7 @@ def init_api(app):
     api = Api(app)
 
     # Register resources
+    api.add_resource(DeviceConfigResource, '/api/config/devices')
     api.add_resource(DeviceListResource, '/api/devices')
     api.add_resource(DeviceStatusResource, '/api/devices/<string:device_ip>')
     api.add_resource(LatestReleaseResource, '/api/releases/latest')

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -159,14 +159,8 @@ class DeviceConfigResource(Resource):
 
         devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
         try:
-            existing = device_config.read_devices(devices_file)
-        except device_config.ConfigReadError as exc:
-            return {'error': 'Conflict', 'details': str(exc)}, 409
-        merged = device_config.merge_devices(existing, cleaned)
-
-        try:
-            device_config.write_devices(devices_file, merged)
-        except device_config.ConfigWriteError as exc:
+            merged = device_config.replace_devices(devices_file, cleaned)
+        except (device_config.ConfigReadError, device_config.ConfigWriteError) as exc:
             return {'error': 'Conflict', 'details': str(exc)}, 409
 
         current_app.logger.info("Device configuration updated: %d device(s)", len(merged))

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -158,7 +158,10 @@ class DeviceConfigResource(Resource):
             return {'error': 'Bad Request', 'details': '; '.join(list_errors)}, 400
 
         devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
-        existing = load_devices_from_file(str(devices_file))
+        try:
+            existing = device_config.read_devices(devices_file)
+        except device_config.ConfigReadError as exc:
+            return {'error': 'Conflict', 'details': str(exc)}, 409
         merged = device_config.merge_devices(existing, cleaned)
 
         try:

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -119,6 +119,56 @@ class DeviceConfigResource(Resource):
             "devices_file": str(devices_file),
         })
 
+    def put(self):
+        """
+        Replace the device configuration
+        ---
+        tags:
+          - configuration
+        responses:
+          200:
+            description: The stored configuration after the write
+          400:
+            description: Validation failed
+          409:
+            description: The configuration file is not writable
+          415:
+            description: Body was not JSON
+        """
+        if not request.is_json:
+            return {'error': 'Unsupported Media Type',
+                    'details': 'Content-Type must be application/json'}, 415
+
+        body = request.get_json(silent=True) or {}
+        submitted = body.get('devices')
+        if not isinstance(submitted, list):
+            return {'error': 'Bad Request', 'details': "'devices' must be a list"}, 400
+
+        schema = DeviceConfigSchema()
+        cleaned = []
+        for index, entry in enumerate(submitted):
+            try:
+                cleaned.append(schema.load(entry))
+            except ValidationError as exc:
+                return {'error': 'Bad Request',
+                        'details': f"Device #{index + 1}: {exc.messages}"}, 400
+
+        list_errors = validate_device_list(cleaned)
+        if list_errors:
+            return {'error': 'Bad Request', 'details': '; '.join(list_errors)}, 400
+
+        devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
+        existing = load_devices_from_file(str(devices_file))
+        merged = device_config.merge_devices(existing, cleaned)
+
+        try:
+            device_config.write_devices(devices_file, merged)
+        except device_config.ConfigWriteError as exc:
+            return {'error': 'Conflict', 'details': str(exc)}, 409
+
+        current_app.logger.info("Device configuration updated: %d device(s)", len(merged))
+        return self.get()
+
 
 # API Resources
 class DeviceListResource(Resource):

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -18,6 +18,47 @@ class ConfigWriteError(Exception):
     """The device configuration could not be written."""
 
 
+MANAGED_FIELDS = ("ip", "username", "password", "dns_name", "timeout")
+
+
+def merge_devices(
+    existing: list[dict[str, Any]],
+    submitted: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge the editor's view over the configuration on disk.
+
+    The submitted list decides membership and order; a device missing from it is
+    deleted. Everything this module does not manage — ``fake``,
+    ``firmware_info``, fields a later version introduces — is carried over from
+    the existing entry, matched by IP. A password is only replaced when one is
+    submitted, and only removed on explicit request.
+    """
+    by_ip = {device.get("ip"): device for device in existing}
+    merged: list[dict[str, Any]] = []
+
+    for entry in submitted:
+        current = dict(by_ip.get(entry.get("ip"), {}))
+        remove_password = bool(entry.get("remove_password"))
+
+        for field in MANAGED_FIELDS:
+            if field == "password":
+                continue
+            if entry.get(field) not in (None, ""):
+                current[field] = entry[field]
+            else:
+                current.pop(field, None)
+
+        if entry.get("password"):
+            current["password"] = entry["password"]
+        elif remove_password:
+            current.pop("password", None)
+
+        current.pop("remove_password", None)
+        merged.append(current)
+
+    return merged
+
+
 def is_writable(target: Path) -> bool:
     """Can we replace ``target`` atomically?
 

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -5,6 +5,7 @@ writes it. It deliberately holds no HTTP or update logic.
 """
 from __future__ import annotations
 
+import copy
 import os
 import shutil
 import tempfile
@@ -18,7 +19,7 @@ class ConfigWriteError(Exception):
     """The device configuration could not be written."""
 
 
-MANAGED_FIELDS = ("ip", "username", "password", "dns_name", "timeout")
+MANAGED_FIELDS: tuple[str, ...] = ("ip", "username", "password", "dns_name", "timeout")
 
 
 def merge_devices(
@@ -31,13 +32,19 @@ def merge_devices(
     deleted. Everything this module does not manage — ``fake``,
     ``firmware_info``, fields a later version introduces — is carried over from
     the existing entry, matched by IP. A password is only replaced when one is
-    submitted, and only removed on explicit request.
+    submitted, and only removed on explicit request. An entry without an ``ip``
+    is skipped on both sides — it cannot be matched and must not be written. If
+    the file on disk has duplicate IPs, the last one wins; earlier duplicates
+    are dropped.
     """
-    by_ip = {device.get("ip"): device for device in existing}
+    by_ip = {device["ip"]: device for device in existing if device.get("ip")}
     merged: list[dict[str, Any]] = []
 
     for entry in submitted:
-        current = dict(by_ip.get(entry.get("ip"), {}))
+        if not entry.get("ip"):
+            continue
+
+        current = copy.deepcopy(by_ip.get(entry["ip"], {}))
         remove_password = bool(entry.get("remove_password"))
 
         for field in MANAGED_FIELDS:

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -5,7 +5,6 @@ writes it. It deliberately holds no HTTP or update logic.
 """
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 import tempfile
@@ -13,8 +12,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigWriteError(Exception):

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import copy
 import os
 import shutil
+import stat
 import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +28,32 @@ class ConfigReadError(Exception):
 MANAGED_FIELDS: tuple[str, ...] = ("ip", "username", "password", "dns_name", "timeout")
 
 
+def read_document(target: Path) -> dict[str, Any]:
+    """Read the full YAML mapping, for preserving keys this module does not manage.
+
+    Nothing writes such a key today, but the per-device merge already goes to
+    lengths to preserve unknown fields (``fake``, ``firmware_info``, ...) and
+    the document level should match: a save must not drop a top-level key it
+    was never asked to touch.
+
+    Same failure semantics as ``read_devices()``: a missing file is an empty
+    mapping, never a reason to raise. Invalid YAML or a document that is not
+    a mapping with a ``devices`` list does raise — the merge baseline must
+    not be silently empty.
+    """
+    if not target.exists():
+        return {}
+    try:
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(f"{target} is not valid YAML: {exc}") from exc
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict) or not isinstance(raw.get("devices", []), list):
+        raise ConfigReadError(f"{target} does not contain a 'devices' list")
+    return raw
+
+
 def read_devices(target: Path) -> list[dict[str, Any]]:
     """Read the configuration for the write path.
 
@@ -35,17 +63,7 @@ def read_devices(target: Path) -> list[dict[str, Any]]:
     must not be silently empty: that would drop every stored password and
     fake-device fixture on the next write.
     """
-    if not target.exists():
-        return []
-    try:
-        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        raise ConfigReadError(f"{target} is not valid YAML: {exc}") from exc
-    if raw is None:
-        return []
-    if not isinstance(raw, dict) or not isinstance(raw.get("devices", []), list):
-        raise ConfigReadError(f"{target} does not contain a 'devices' list")
-    return list(raw.get("devices") or [])
+    return list(read_document(target).get("devices") or [])
 
 
 def merge_devices(
@@ -108,15 +126,27 @@ def is_writable(target: Path) -> bool:
         return False
 
 
-def write_devices(target: Path, devices: list[dict[str, Any]]) -> None:
-    """Replace the device file atomically, keeping one backup generation."""
+def write_devices(
+    target: Path,
+    devices: list[dict[str, Any]],
+    document: dict[str, Any] | None = None,
+) -> None:
+    """Replace the device file atomically, keeping one backup generation.
+
+    ``document`` is the previously-read full mapping (see ``read_document()``);
+    any key besides ``devices`` in it is carried over unchanged. Omit it to
+    write a file containing only ``devices`` — what every caller before this
+    parameter existed did.
+    """
     if not is_writable(target):
         raise ConfigWriteError(
             f"{target} is not writable. If the file is bind-mounted individually, "
             "mount its directory instead."
         )
 
-    payload = yaml.safe_dump({"devices": devices}, sort_keys=False, allow_unicode=True)
+    body = dict(document) if document else {}
+    body["devices"] = devices
+    payload = yaml.safe_dump(body, sort_keys=False, allow_unicode=True)
 
     fd, temp_name = tempfile.mkstemp(dir=str(target.parent), prefix=".devices-", suffix=".tmp")
     temp_path = Path(temp_name)
@@ -126,8 +156,35 @@ def write_devices(target: Path, devices: list[dict[str, Any]]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         if target.exists():
+            # mkstemp() creates the file 0600, and Path.replace() carries that
+            # onto the target — silently tightening devices.yaml's permissions
+            # on the first UI save and locking out the SSH editing path the
+            # design promises stays open. Match the target's mode first.
+            temp_path.chmod(stat.S_IMODE(target.stat().st_mode))
             shutil.copy2(target, target.with_suffix(target.suffix + ".bak"))
         temp_path.replace(target)
     except OSError as exc:
         temp_path.unlink(missing_ok=True)
         raise ConfigWriteError(f"Could not write {target}: {exc}") from exc
+
+
+_replace_lock = threading.Lock()
+
+
+def replace_devices(target: Path, submitted: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Read, merge and write in one atomic unit, for concurrent callers.
+
+    ``read → merge → write`` is not atomic across requests. With two
+    overlapping writes — two browser tabs, a fast double-click, the gthread
+    worker makes both reachable — the second writer's ``.bak`` would be the
+    *first* writer's output, not the original pre-edit state, so that state is
+    gone from both the file and the backup. Holding this lock across the whole
+    sequence serialises overlapping saves so each one's backup is a real,
+    previously-live version of the file.
+    """
+    with _replace_lock:
+        document = read_document(target)
+        existing = list(document.get("devices") or [])
+        merged = merge_devices(existing, submitted)
+        write_devices(target, merged, document=document)
+        return merged

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -127,7 +127,7 @@ def write_devices(target: Path, devices: list[dict[str, Any]]) -> None:
             os.fsync(handle.fileno())
         if target.exists():
             shutil.copy2(target, target.with_suffix(target.suffix + ".bak"))
-        os.replace(temp_path, target)
+        temp_path.replace(target)
     except OSError as exc:
         temp_path.unlink(missing_ok=True)
         raise ConfigWriteError(f"Could not write {target}: {exc}") from exc

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -19,7 +19,33 @@ class ConfigWriteError(Exception):
     """The device configuration could not be written."""
 
 
+class ConfigReadError(Exception):
+    """The device configuration exists but could not be understood."""
+
+
 MANAGED_FIELDS: tuple[str, ...] = ("ip", "username", "password", "dns_name", "timeout")
+
+
+def read_devices(target: Path) -> list[dict[str, Any]]:
+    """Read the configuration for the write path.
+
+    Unlike ``utils.load_devices_from_file()``, which answers every failure
+    with an empty list, this raises. An empty answer here means the file
+    really is empty — never that it could not be parsed. The merge baseline
+    must not be silently empty: that would drop every stored password and
+    fake-device fixture on the next write.
+    """
+    if not target.exists():
+        return []
+    try:
+        raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigReadError(f"{target} is not valid YAML: {exc}") from exc
+    if raw is None:
+        return []
+    if not isinstance(raw, dict) or not isinstance(raw.get("devices", []), list):
+        raise ConfigReadError(f"{target} does not contain a 'devices' list")
+    return list(raw.get("devices") or [])
 
 
 def merge_devices(

--- a/app/tasmota/device_config.py
+++ b/app/tasmota/device_config.py
@@ -1,0 +1,62 @@
+"""Read, merge and atomically write the device configuration file.
+
+`devices.yaml` is the source of truth. This module is the only place that
+writes it. It deliberately holds no HTTP or update logic.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigWriteError(Exception):
+    """The device configuration could not be written."""
+
+
+def is_writable(target: Path) -> bool:
+    """Can we replace ``target`` atomically?
+
+    Checking the directory alone is not enough. With a single-file bind mount
+    the directory is writable while the file itself is a mount point, and
+    ``os.replace()`` onto a mount point fails with EBUSY — at save time, long
+    after the UI told the user everything was fine.
+    """
+    if not os.access(target.parent, os.W_OK):
+        return False
+    try:
+        return not target.is_mount()
+    except OSError:  # pragma: no cover - unreadable path, treat as not writable
+        return False
+
+
+def write_devices(target: Path, devices: list[dict[str, Any]]) -> None:
+    """Replace the device file atomically, keeping one backup generation."""
+    if not is_writable(target):
+        raise ConfigWriteError(
+            f"{target} is not writable. If the file is bind-mounted individually, "
+            "mount its directory instead."
+        )
+
+    payload = yaml.safe_dump({"devices": devices}, sort_keys=False, allow_unicode=True)
+
+    fd, temp_name = tempfile.mkstemp(dir=str(target.parent), prefix=".devices-", suffix=".tmp")
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if target.exists():
+            shutil.copy2(target, target.with_suffix(target.suffix + ".bak"))
+        os.replace(temp_path, target)
+    except OSError as exc:
+        temp_path.unlink(missing_ok=True)
+        raise ConfigWriteError(f"Could not write {target}: {exc}") from exc

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -194,23 +194,23 @@
         </section>
 
         <section class="section" x-data="devicesEditor()" x-init="init()">
-          <h2 class="title is-4">Geräte verwalten</h2>
+          <h2 class="title is-4">Manage Devices</h2>
 
           <div class="notification is-warning" x-show="!writable" x-cloak>
-            Die Konfigurationsdatei <span x-text="devicesFile"></span> ist nicht
-            schreibbar. Wird sie als einzelne Datei ins Image gemountet, muss
-            stattdessen ihr Verzeichnis gemountet werden — siehe
+            The configuration file <span x-text="devicesFile"></span> is not
+            writable. If it is mounted into the image as a single file, its
+            directory must be mounted instead — see
             <code>compose.example.yml</code>.
           </div>
 
           <div class="notification is-danger" x-show="error" x-cloak x-text="error"></div>
-          <div class="notification is-success" x-show="saved" x-cloak>Gespeichert.</div>
+          <div class="notification is-success" x-show="saved" x-cloak>Saved.</div>
 
           <table class="table is-fullwidth">
             <thead>
               <tr>
-                <th>IP</th><th>Name</th><th>Benutzer</th><th>Passwort</th>
-                <th>Timeout</th><th></th>
+                <th scope="col">IP</th><th scope="col">Name</th><th scope="col">Username</th><th scope="col">Password</th>
+                <th scope="col">Timeout</th><th scope="col"></th>
               </tr>
             </thead>
             <tbody>
@@ -218,33 +218,38 @@
                 <tr>
                   <td><input class="input" type="text" x-model="device.ip"
                              :disabled="!writable" placeholder="192.168.8.191"
-                             title="IP-Adresse des Geräts eintragen"></td>
+                             aria-label="Device IP address"
+                             title="Enter the device's IP address — changing it makes this a new device, so its stored password is not carried over"></td>
                   <td><input class="input" type="text" x-model="device.dns_name"
                              :disabled="!writable"
-                             title="Anzeigenamen für das Gerät eintragen"></td>
+                             aria-label="Device display name"
+                             title="Enter a display name for the device"></td>
                   <td><input class="input" type="text" x-model="device.username"
                              :disabled="!writable"
-                             title="Benutzernamen für die Geräte-Anmeldung eintragen"></td>
+                             aria-label="Device username"
+                             title="Enter the username for the device login"></td>
                   <td>
                     <input class="input" type="password" x-model="device.password"
                            :disabled="!writable"
-                           :placeholder="device.has_password ? '•••••••• (gesetzt)' : 'kein Passwort'"
-                           title="Neues Passwort eintragen — leer lassen behält das gespeicherte">
+                           :placeholder="device.has_password ? '•••••••• (set)' : 'no password'"
+                           aria-label="Device password"
+                           title="Enter a new password — leave blank to keep the stored one">
                     <button class="button is-small is-text" type="button"
                             x-show="device.has_password" :disabled="!writable"
                             @click="clearPassword(device)"
-                            title="Gespeichertes Passwort entfernen — das Gerät wird danach ohne Anmeldung angesprochen">
-                      Passwort entfernen
+                            title="Remove the stored password — the device will then be contacted without credentials">
+                      Remove password
                     </button>
                   </td>
                   <td><input class="input" type="number" x-model="device.timeout"
                              :disabled="!writable" min="60" max="600" placeholder="240"
-                             title="Timeout in Sekunden für dieses Gerät setzen (60–600)"></td>
+                             aria-label="Device timeout in seconds"
+                             title="Set the timeout in seconds for this device (60–600)"></td>
                   <td>
                     <button class="button is-danger is-small" type="button"
                             :disabled="!writable" @click="removeDevice(index)"
-                            title="Gerät aus der Konfiguration entfernen — wird erst beim Speichern wirksam">
-                      Entfernen
+                            title="Remove the device from the configuration — applied when you save">
+                      Remove
                     </button>
                   </td>
                 </tr>
@@ -252,14 +257,19 @@
             </tbody>
           </table>
 
+          <p class="help">
+            Changing a device's IP address makes it a new device — its stored
+            password is not carried over and must be entered again.
+          </p>
+
           <div class="buttons">
             <button class="button" type="button" :disabled="!writable" @click="addDevice()"
-                    title="Neues Gerät zur Liste hinzufügen">Gerät hinzufügen</button>
+                    title="Add a new device to the list">Add Device</button>
             <button class="button is-primary" type="button"
                     :disabled="!writable || saving" :class="{'is-loading': saving}"
                     @click="save()"
-                    title="Geänderte Geräteliste in die Konfigurationsdatei schreiben">
-              Speichern
+                    title="Write the changed device list to the configuration file">
+              Save
             </button>
           </div>
         </section>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-    <div x-data="tasmotaApp()" x-init="init()">
+    <div x-data="tasmotaApp()" x-init="init()" @devices-changed.window="refreshDevices()">
         <nav class="navbar is-primary" role="navigation" aria-label="main navigation" x-data="{ navOpen: false }">
             <div class="navbar-brand">
                 <a class="navbar-item" href="/" title="Return to home page">
@@ -214,6 +214,9 @@
               </tr>
             </thead>
             <tbody>
+              <tr x-show="loading" x-cloak>
+                <td colspan="6" class="has-text-centered">Loading…</td>
+              </tr>
               <template x-for="(device, index) in devices" :key="index">
                 <tr>
                   <td><input class="input" type="text" x-model="device.ip"
@@ -263,10 +266,10 @@
           </p>
 
           <div class="buttons">
-            <button class="button" type="button" :disabled="!writable" @click="addDevice()"
+            <button class="button" type="button" :disabled="!writable || !loaded" @click="addDevice()"
                     title="Add a new device to the list">Add Device</button>
             <button class="button is-primary" type="button"
-                    :disabled="!writable || saving" :class="{'is-loading': saving}"
+                    :disabled="!writable || !loaded || saving" :class="{'is-loading': saving}"
                     @click="save()"
                     title="Write the changed device list to the configuration file">
               Save

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -77,7 +77,7 @@
                 </div>
                 
                 <!-- Error notification -->
-                <div class="notification is-danger" x-show="error" x-cloak>
+                <div class="notification is-danger" x-show="error" x-cloak data-testid="device-error">
                     <button class="delete" @click="error = null"></button>
                     <span x-text="error"></span>
                 </div>
@@ -203,7 +203,7 @@
             <code>compose.example.yml</code>.
           </div>
 
-          <div class="notification is-danger" x-show="error" x-cloak x-text="error"></div>
+          <div class="notification is-danger" x-show="error" x-cloak x-text="error" data-testid="editor-error"></div>
           <div class="notification is-success" x-show="saved" x-cloak>Saved.</div>
 
           <table class="table is-fullwidth">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -192,7 +192,78 @@
                 </div>
             </div>
         </section>
-        
+
+        <section class="section" x-data="devicesEditor()" x-init="init()">
+          <h2 class="title is-4">Geräte verwalten</h2>
+
+          <div class="notification is-warning" x-show="!writable" x-cloak>
+            Die Konfigurationsdatei <span x-text="devicesFile"></span> ist nicht
+            schreibbar. Wird sie als einzelne Datei ins Image gemountet, muss
+            stattdessen ihr Verzeichnis gemountet werden — siehe
+            <code>compose.example.yml</code>.
+          </div>
+
+          <div class="notification is-danger" x-show="error" x-cloak x-text="error"></div>
+          <div class="notification is-success" x-show="saved" x-cloak>Gespeichert.</div>
+
+          <table class="table is-fullwidth">
+            <thead>
+              <tr>
+                <th>IP</th><th>Name</th><th>Benutzer</th><th>Passwort</th>
+                <th>Timeout</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="(device, index) in devices" :key="index">
+                <tr>
+                  <td><input class="input" type="text" x-model="device.ip"
+                             :disabled="!writable" placeholder="192.168.8.191"
+                             title="IP-Adresse des Geräts eintragen"></td>
+                  <td><input class="input" type="text" x-model="device.dns_name"
+                             :disabled="!writable"
+                             title="Anzeigenamen für das Gerät eintragen"></td>
+                  <td><input class="input" type="text" x-model="device.username"
+                             :disabled="!writable"
+                             title="Benutzernamen für die Geräte-Anmeldung eintragen"></td>
+                  <td>
+                    <input class="input" type="password" x-model="device.password"
+                           :disabled="!writable"
+                           :placeholder="device.has_password ? '•••••••• (gesetzt)' : 'kein Passwort'"
+                           title="Neues Passwort eintragen — leer lassen behält das gespeicherte">
+                    <button class="button is-small is-text" type="button"
+                            x-show="device.has_password" :disabled="!writable"
+                            @click="clearPassword(device)"
+                            title="Gespeichertes Passwort entfernen — das Gerät wird danach ohne Anmeldung angesprochen">
+                      Passwort entfernen
+                    </button>
+                  </td>
+                  <td><input class="input" type="number" x-model="device.timeout"
+                             :disabled="!writable" min="60" max="600" placeholder="240"
+                             title="Timeout in Sekunden für dieses Gerät setzen (60–600)"></td>
+                  <td>
+                    <button class="button is-danger is-small" type="button"
+                            :disabled="!writable" @click="removeDevice(index)"
+                            title="Gerät aus der Konfiguration entfernen — wird erst beim Speichern wirksam">
+                      Entfernen
+                    </button>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+
+          <div class="buttons">
+            <button class="button" type="button" :disabled="!writable" @click="addDevice()"
+                    title="Neues Gerät zur Liste hinzufügen">Gerät hinzufügen</button>
+            <button class="button is-primary" type="button"
+                    :disabled="!writable || saving" :class="{'is-loading': saving}"
+                    @click="save()"
+                    title="Geänderte Geräteliste in die Konfigurationsdatei schreiben">
+              Speichern
+            </button>
+          </div>
+        </section>
+
         <!-- Update confirmation modal -->
         <div class="modal" :class="{'is-active': showUpdateModal}">
             <div class="modal-background" @click="showUpdateModal = false"></div>
@@ -235,5 +306,6 @@
     </div>
 
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/devices-editor.js') }}"></script>
 </body>
 </html>

--- a/compose.example.yml
+++ b/compose.example.yml
@@ -15,12 +15,14 @@ services:
     ports:
       - "5001:5001"
     volumes:
-      - ./devices.yaml:/app/devices.yaml
+      # The directory is mounted, not the file: replacing a bind-mounted file
+      # fails with EBUSY, so the editor could not write it.
+      - ./config:/app/config
       - ./logs:/app/logs
       - ./app/tasmota/cache:/app/app/tasmota/cache
     environment:
       # Use environment variable with fallback
-      - DEVICES_FILE=${DEVICES_FILE:-devices.yaml}
+      - DEVICES_FILE=${DEVICES_FILE:-/app/config/devices.yaml}
       # SECRET_KEY: leave unset and the app generates an ephemeral random key at
       # startup. Set a strong, persistent value only if you need sessions to
       # survive restarts (the bundled UI currently uses no server-side sessions).

--- a/docs/audit-2026-07/2026-08-07-devices-editor-design.md
+++ b/docs/audit-2026-07/2026-08-07-devices-editor-design.md
@@ -1,0 +1,243 @@
+# Design: Geräte-Editor im Browser
+
+Stand 2026-08-07. Erster von zwei Zyklen zu [#99](https://github.com/dodjango/tasmota-auto-updater/issues/99).
+Der zweite Zyklus — Netzwerk-Discovery — bekommt eine eigene Spec, sobald der
+Editor steht.
+
+## Ziel und Abgrenzung
+
+Die Geräteliste in der Web-UI pflegen, statt `devices.yaml` per SSH zu
+editieren. Anlegen, Ändern, Löschen.
+
+Nicht Ziel: Discovery, Gerätegruppen, Import/Export, Mehrbenutzer-Betrieb,
+Historie der Änderungen.
+
+**Eine verbreitete Annahme vorab korrigiert:** ein Neustart des Containers ist
+für Konfigurationsänderungen heute schon nicht nötig. `api.py:73` und `:139`
+rufen `load_devices_from_file()` bei *jedem* Request neu auf, es gibt keinen
+Cache. Der Wert des Editors liegt also nicht im Wegfall des Neustarts, sondern
+darin, dass kein SSH mehr nötig ist, dass vor dem Speichern validiert wird, und
+dass Discovery-Funde später irgendwo landen können.
+
+## Getroffene Entscheidungen
+
+Diese vier hat der Betreiber entschieden; sie sind die Grundlage von allem
+Weiteren.
+
+| Frage | Entscheidung |
+|---|---|
+| Was ist die Wahrheit? | **Die YAML-Datei.** Keine Datenbank. Handarbeit per SSH bleibt jederzeit möglich. |
+| Gleichzeitige Änderungen? | **Letzter Schreiber gewinnt**, keine Konflikterkennung. Bewusst in Kauf genommen. |
+| Passwörter? | **Nur schreibbar, nie lesbar.** Leeres Feld heißt „behalten", ein Knopf entfernt das Passwort. |
+| Deployment? | **Verzeichnis-Mount** statt Datei-Mount. Breaking Change, dokumentiert. |
+
+Zum zweiten Punkt: ein atomarer Schreibvorgang mit Backup der Vorgängerversion
+ist trotzdem vorgesehen. Das ist keine Konflikterkennung — es macht eine
+überschriebene Datei nur wiederherstellbar.
+
+## Warum der Editor eine eigene Ressource bekommt
+
+`/api/devices` ist die **operative** Sicht und für den Editor unbrauchbar:
+
+- Es maskiert das Passwort zu `'********'` — ein Wert, der zurückgeschrieben das
+  echte Passwort zerstören würde.
+- Es überschreibt `dns_name` mit dem *aufgelösten* Namen, und wenn keiner
+  auflösbar ist, **mit der IP selbst** (`api.py:80-84`). Ein Round-Trip dieser
+  Antwort schriebe `dns_name: 192.168.8.191` in die Konfiguration jedes Geräts,
+  das gar keinen Namen hat.
+
+Der Editor bekommt deshalb `/api/config/devices` mit den **rohen konfigurierten**
+Feldern. `/api/devices` bleibt unverändert, damit weder die bestehende UI noch
+die dokumentierte API brechen.
+
+## API
+
+### `GET /api/config/devices`
+
+Liefert die Konfiguration, wie sie in der Datei steht — ohne DNS-Auflösung, ohne
+Anreicherung:
+
+```json
+{
+  "devices": [
+    {"ip": "192.168.8.191", "username": "admin", "has_password": true,
+     "dns_name": "flur", "timeout": 240}
+  ],
+  "writable": true,
+  "devices_file": "/app/config/devices.yaml"
+}
+```
+
+`has_password` ist ein Boolean; das Passwort selbst verlässt den Server nie.
+`writable` sagt der UI, ob der Speichern-Knopf überhaupt aktiv sein darf.
+
+### `PUT /api/config/devices`
+
+Ersetzt die Liste. Der Body ist `{"devices": [...]}`.
+
+Eine Teil-Update-Semantik gibt es bewusst nicht: bei „YAML ist die Wahrheit" und
+„letzter Schreiber gewinnt" ist das Ersetzen der ganzen Liste die ehrlichste
+Form, und die UI hält die Liste ohnehin komplett.
+
+Antworten: `200` mit der neuen Liste, `400` bei Validierungsfehlern, `409` wenn
+das Verzeichnis nicht schreibbar ist, `415` wenn der Body kein JSON ist. Die
+JSON-Pflicht wird in der Ressource selbst geprüft, wie in `api.py:318` und
+`:448` — sie ist im Projekt nicht global.
+
+Zugriffsschutz: `/api/*` ist seit v0.5.0 fail-closed (UI-Session-Cookie oder
+`X-API-Key`), es braucht nichts Zusätzliches.
+
+## Die Merge-Regel
+
+**Der Server schreibt nicht, was der Client schickt.** Er liest die Datei, führt
+pro Gerät die verwalteten Felder über den bestehenden Eintrag und schreibt das
+Ergebnis. Identität ist die IP.
+
+Verwaltete Felder: `ip`, `username`, `password`, `dns_name`, `timeout`.
+
+Das löst vier Dinge mit einer Regel:
+
+1. Das Passwort bleibt erhalten, wenn der Client keins schickt.
+2. `fake` und `firmware_info` in `devices-dev.yaml` überleben, obwohl der Editor
+   sie nicht kennt.
+3. Felder, die eine spätere Version einführt, gehen nicht verloren.
+4. Ein Gerät, das im Payload fehlt, wird gelöscht — das ist die einzige Art zu
+   löschen, und sie ist explizit.
+
+**Konsequenz, die in die UI gehört:** wird die IP eines Geräts geändert, gilt es
+als neues Gerät. Das Passwort lässt sich nicht mehr zuordnen und muss neu
+eingegeben werden.
+
+### Passwort-Übergabe
+
+| Client schickt | Wirkung |
+|---|---|
+| kein `password`-Feld | bestehendes Passwort bleibt |
+| `password: "neu"` | wird ersetzt |
+| `remove_password: true` | Passwort wird gelöscht |
+
+`remove_password` ist ein reines Steuerfeld und landet nie in der Datei.
+
+## Validierung
+
+Marshmallow, wie im Rest des Projekts, mit `unknown = RAISE`:
+
+| Feld | Regel |
+|---|---|
+| `ip` | Pflicht, geprüft über das vorhandene `is_valid_ip_address()` |
+| `username` | optional, String |
+| `password` | optional, String, nur schreibend |
+| `dns_name` | optional, String |
+| `timeout` | optional, Integer 60–600 (wie `DeviceUpdateSchema`) |
+
+Zusätzlich: **doppelte IPs werden abgelehnt** — dieselbe Regel, die die CLI in
+`main()` zieht, aus demselben Grund (zwei Einträge mit derselben IP kollabieren
+in jeder IP-basierten Zuordnung).
+
+`fake` und `firmware_info` sind **nicht setzbar**. `unknown = RAISE` lehnt sie
+ab. Grund: wer ein echtes Gerät zum Fake-Gerät erklären kann, bekommt frei
+erfundene Erfolgsmeldungen — eine Lüge, die genau die Sorte ist, gegen die das
+Projekt sonst überall absichert.
+
+`is_valid_ip_address()` blockt bewusst Loopback, Link-local und die
+Metadata-Adresse 169.254.169.254. Diese Sperre bleibt: der Editor darf keine
+Adressen in die Konfiguration schreiben, die die SSRF-Absicherung der
+Update-Endpunkte umgehen würden.
+
+## Schreibpfad
+
+Neues Modul `app/tasmota/config_writer.py`, eine Verantwortung: die Gerätedatei
+sicher ersetzen.
+
+1. Schreibbarkeit feststellen (siehe unten — es reicht nicht, das Verzeichnis zu
+   prüfen).
+2. Temp-Datei **im selben Verzeichnis** schreiben, `flush()` + `os.fsync()`.
+3. Bestehende Datei nach `<name>.bak` kopieren.
+4. `os.replace(temp, ziel)` — atomar innerhalb desselben Dateisystems.
+
+Schritt 2 muss im selben Verzeichnis passieren, sonst ist `os.replace()` ein
+Kopiervorgang über Dateisystemgrenzen und nicht mehr atomar.
+
+Das Backup hält **eine** Generation: jedes Speichern überschreibt `<name>.bak`.
+Mehr wäre eine Versionierung, und die gehört nicht in dieses Feature.
+
+### Schreibbarkeit richtig feststellen
+
+`os.access(verzeichnis, os.W_OK)` allein genügt **nicht**. Beim alten
+Datei-Mount ist `/app` sehr wohl schreibbar — nur die Zieldatei selbst ist ein
+Mountpoint, und `os.replace()` darüber scheitert erst im Moment des Speicherns
+mit `EBUSY`. Die API meldete dann `writable: true` und liefe hinterher in einen
+Fehler.
+
+Die Prüfung ist deshalb zweiteilig:
+
+```python
+writable = os.access(target.parent, os.W_OK) and not target.is_mount()
+```
+
+`Path.is_mount()` erkennt den Datei-Bind-Mount, weil sich `st_dev` von Datei und
+Elternverzeichnis unterscheiden. Beide Bedingungen müssen erfüllt sein, sonst
+ist der Editor schreibgeschützt — und zwar bevor der Benutzer etwas eintippt,
+nicht danach.
+
+**Warum das Verzeichnis gemountet sein muss:** ein Bind-Mount auf eine *Datei*
+macht diese Datei zum Mountpoint, und ein `rename()` darüber scheitert mit
+`EBUSY`. Mit dem bisherigen `./devices.yaml:/app/devices.yaml` funktioniert der
+Schreibpfad also nicht. Deshalb der Wechsel auf ein Verzeichnis-Mount.
+
+Erkennt der Writer ein nicht schreibbares Ziel, meldet er das als klaren Fehler.
+Die UI zeigt den Editor dann schreibgeschützt mit dem Hinweis, wie man auf ein
+Verzeichnis-Mount umstellt — kein Traceback, kein stiller Fehlschlag.
+
+## Frontend
+
+Alpine, wie der Rest der UI. Eine Geräteliste mit Bearbeiten, Hinzufügen,
+Löschen und **einem** Speichern-Knopf für die ganze Liste.
+
+Nach den Projektkonventionen: jedes interaktive Element bekommt einen Tooltip,
+der mit einem Verb beginnt; das Löschen bekommt zusätzlich eine Bestätigung und
+eine Warnung im Tooltip. Bedienbarkeit per Tastatur und Screenreader-Ansage
+gehören dazu, nicht als Nacharbeit.
+
+Ist `writable` falsch, sind alle Bedienelemente deaktiviert und ein Hinweis
+erklärt warum.
+
+## Tests
+
+- **Unit** für `config_writer`: atomarer Ersatz, Backup entsteht, nicht
+  schreibbares Verzeichnis wird erkannt, Temp-Datei landet im Zielverzeichnis.
+- **Unit** für die Merge-Regel: Passwort bleibt/wird ersetzt/wird entfernt;
+  `fake` und `firmware_info` überleben; fehlendes Gerät wird gelöscht;
+  IP-Änderung erzeugt ein neues Gerät ohne Passwort.
+- **Unit** für die Validierung: ungültige IP, Loopback, doppelte IPs,
+  `timeout`-Grenzen, `fake` wird abgelehnt.
+- **Integration** über den Flask-Test-Client: `GET` maskiert, `PUT` schreibt,
+  `415` ohne JSON, `409` bei nicht schreibbarem Ziel.
+- **E2E** (Playwright): Gerät anlegen, ändern, löschen, speichern, Seite neu
+  laden und den Stand wiederfinden.
+
+Keine neuen pytest-Marker.
+
+## Doku
+
+`compose.example.yml` auf das Verzeichnis-Mount umstellen,
+`docs/configuration.md` und `docs/container-setup.md` entsprechend, README-Check
+nach Projektregel. Ein **Migrationshinweis** gehört in die Release-Notes: wer
+`./devices.yaml:/app/devices.yaml` mountet, muss umstellen, sonst bleibt der
+Editor schreibgeschützt.
+
+Zwei Verhaltensweisen gehören ausdrücklich in die Doku, weil sie überraschen:
+Kommentare in der YAML gehen beim Speichern über die UI verloren, und eine
+geänderte IP verlangt das Passwort neu.
+
+## Restrisiken
+
+- **Letzter Schreiber gewinnt** ist eine bewusste Entscheidung, kein Versehen.
+  Wer parallel per SSH und über die UI editiert, verliert eine der beiden
+  Änderungen. Das Backup macht sie wiederherstellbar, nicht sichtbar.
+- **Klartext-Passwörter in der Datei** bleiben, wie sie sind. Der Editor
+  verschlechtert das nicht, aber er macht die Datei zum Ziel eines
+  Schreibzugriffs über HTTP — im LAN ohne TLS ist das ein Restrisiko, das ins
+  Threat-Model (#74) gehört.
+- **Kein Audit-Log.** Wer wann welches Gerät geändert hat, ist nicht
+  nachvollziehbar. Für einen Einzelbetreiber vertretbar.

--- a/docs/audit-2026-07/2026-08-07-devices-editor-plan.md
+++ b/docs/audit-2026-07/2026-08-07-devices-editor-plan.md
@@ -1,0 +1,1239 @@
+# Devices Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Manage the device list from the web UI — add, edit, delete — with `devices.yaml` remaining the source of truth.
+
+**Architecture:** A new module `app/tasmota/device_config.py` owns reading, merging and atomically writing the device configuration. A new API resource `/api/config/devices` (GET/PUT) exposes it, deliberately separate from the operational `/api/devices`. A separate Alpine component in its own file drives the UI.
+
+**Tech Stack:** Python 3.10+, Flask-RESTful, Marshmallow, PyYAML, Alpine.js 3, pytest, Playwright.
+
+## Global Constraints
+
+- Design document: [`2026-08-07-devices-editor-design.md`](2026-08-07-devices-editor-design.md). Read it before starting.
+- **The password never leaves the server.** `GET` returns `has_password: true|false`, never the value.
+- **The server does not write what the client sends.** It reads the file, merges the managed fields (`ip`, `username`, `password`, `dns_name`, `timeout`) over the existing entry matched by IP, and writes the result. Unmanaged fields (`fake`, `firmware_info`, anything a later version adds) survive untouched.
+- A device absent from the payload is deleted. That is the only way to delete.
+- `fake` and `firmware_info` are **not settable** through the API — `unknown = RAISE`.
+- IP validation goes through the existing `is_valid_ip_address()`, which blocks loopback, link-local and 169.254.169.254. That block stays.
+- Duplicate IPs are rejected.
+- Writability check is `os.access(parent, W_OK) and not target.is_mount()` — the directory alone is not enough, because with a single-file bind mount the directory is writable while `os.replace()` fails with `EBUSY` at save time.
+- Atomic write: temp file **in the same directory**, `fsync`, copy the previous version to `<name>.bak` (one generation only), then `os.replace()`.
+- Style from `pyproject.toml`: line length 100, ruff with `PTH` (use `pathlib`), mypy `disallow_untyped_defs = true` — annotate every function.
+- Every interactive element gets a tooltip starting with a verb; destructive actions get a warning and a confirmation (project frontend convention).
+- No new runtime dependencies.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| Create `app/tasmota/device_config.py` | Read, merge and atomically write the device configuration file. ~120 lines. |
+| Create `app/static/js/devices-editor.js` | The editor's Alpine component. Kept out of `app/static/js/app.js`, which is already 499 lines. |
+| Modify `app/tasmota/api.py` | Add `DeviceConfigSchema` and the `DeviceConfigResource` (GET/PUT), register the route. |
+| Modify `app/templates/index.html` | Editor section plus the new script tag. |
+| Modify `compose.example.yml` | Directory mount instead of the single-file mount. |
+| Create `tests/test_device_config.py` | Unit tests for writer and merge. |
+| Create `tests/test_config_api.py` | Flask-test-client integration tests. |
+| Create `tests/e2e/test_devices_editor.py` | Playwright flow, against its own app instance on a copy of the fixture. |
+| Modify `docs/configuration.md`, `docs/container-setup.md`, `README.md` | Document the editor and the mount migration. |
+
+---
+
+### Task 1: Writability detection and the atomic write
+
+**Files:**
+- Create: `app/tasmota/device_config.py`
+- Test: `tests/test_device_config.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `is_writable(target: Path) -> bool`, `write_devices(target: Path, devices: list[dict[str, Any]]) -> None`, `ConfigWriteError(Exception)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_device_config.py
+"""Unit tests for reading, merging and writing the device configuration."""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.tasmota import device_config
+
+
+def test_is_writable_accepts_a_normal_file(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    assert device_config.is_writable(target) is True
+
+
+def test_is_writable_accepts_a_missing_file_in_a_writable_directory(tmp_path):
+    assert device_config.is_writable(tmp_path / "devices.yaml") is True
+
+
+def test_is_writable_rejects_an_unwritable_directory(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    tmp_path.chmod(0o500)
+    try:
+        assert device_config.is_writable(target) is False
+    finally:
+        tmp_path.chmod(0o700)
+
+
+def test_write_devices_replaces_the_file(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\n", encoding="utf-8")
+
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+
+    assert yaml.safe_load(target.read_text(encoding="utf-8")) == {"devices": [{"ip": "2.2.2.2"}]}
+
+
+def test_write_devices_keeps_one_backup_generation(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\n", encoding="utf-8")
+
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    device_config.write_devices(target, [{"ip": "3.3.3.3"}])
+
+    backup = yaml.safe_load((tmp_path / "devices.yaml.bak").read_text(encoding="utf-8"))
+    assert backup == {"devices": [{"ip": "2.2.2.2"}]}, "the backup holds the previous version"
+
+
+def test_write_devices_leaves_no_temp_file_behind(tmp_path):
+    target = tmp_path / "devices.yaml"
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml"]
+
+
+def test_write_devices_refuses_an_unwritable_target(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    tmp_path.chmod(0o500)
+    try:
+        with pytest.raises(device_config.ConfigWriteError):
+            device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    finally:
+        tmp_path.chmod(0o700)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_device_config.py -v -o addopts=""`
+Expected: FAIL — `ImportError: cannot import name 'device_config'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/tasmota/device_config.py
+"""Read, merge and atomically write the device configuration file.
+
+`devices.yaml` is the source of truth. This module is the only place that
+writes it. It deliberately holds no HTTP or update logic.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigWriteError(Exception):
+    """The device configuration could not be written."""
+
+
+def is_writable(target: Path) -> bool:
+    """Can we replace ``target`` atomically?
+
+    Checking the directory alone is not enough. With a single-file bind mount
+    the directory is writable while the file itself is a mount point, and
+    ``os.replace()`` onto a mount point fails with EBUSY — at save time, long
+    after the UI told the user everything was fine.
+    """
+    if not os.access(target.parent, os.W_OK):
+        return False
+    try:
+        return not target.is_mount()
+    except OSError:  # pragma: no cover - unreadable path, treat as not writable
+        return False
+
+
+def write_devices(target: Path, devices: list[dict[str, Any]]) -> None:
+    """Replace the device file atomically, keeping one backup generation."""
+    if not is_writable(target):
+        raise ConfigWriteError(
+            f"{target} is not writable. If the file is bind-mounted individually, "
+            "mount its directory instead."
+        )
+
+    payload = yaml.safe_dump({"devices": devices}, sort_keys=False, allow_unicode=True)
+
+    fd, temp_name = tempfile.mkstemp(dir=str(target.parent), prefix=".devices-", suffix=".tmp")
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if target.exists():
+            shutil.copy2(target, target.with_suffix(target.suffix + ".bak"))
+        os.replace(temp_path, target)
+    except OSError as exc:
+        temp_path.unlink(missing_ok=True)
+        raise ConfigWriteError(f"Could not write {target}: {exc}") from exc
+```
+
+Note `target.with_suffix(target.suffix + ".bak")` yields `devices.yaml.bak`, not
+`devices.bak` — `with_suffix` replaces the last suffix, so the current one is
+concatenated deliberately.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_device_config.py -v -o addopts=""`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/device_config.py tests/test_device_config.py
+git commit -m "feat(config): add atomic device-config writer with writability detection"
+```
+
+---
+
+### Task 2: The merge rule
+
+**Files:**
+- Modify: `app/tasmota/device_config.py`
+- Test: `tests/test_device_config.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 beyond the module.
+- Produces: `MANAGED_FIELDS: tuple[str, ...]`, `merge_devices(existing: list[dict[str, Any]], submitted: list[dict[str, Any]]) -> list[dict[str, Any]]`.
+
+This is the heart of the feature. The submitted list wins on order and
+membership; the existing entries contribute everything the editor does not
+manage.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_device_config.py
+
+
+def test_merge_keeps_the_existing_password_when_none_is_submitted():
+    existing = [{"ip": "1.1.1.1", "password": "secret", "username": "admin"}]
+    submitted = [{"ip": "1.1.1.1", "username": "admin"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1", "username": "admin", "password": "secret"}
+    ]
+
+
+def test_merge_replaces_a_submitted_password():
+    existing = [{"ip": "1.1.1.1", "password": "old"}]
+    submitted = [{"ip": "1.1.1.1", "password": "new"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1", "password": "new"}
+    ]
+
+
+def test_merge_removes_the_password_on_request():
+    existing = [{"ip": "1.1.1.1", "password": "old"}]
+    submitted = [{"ip": "1.1.1.1", "remove_password": True}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
+
+
+def test_merge_never_writes_the_control_field():
+    existing = [{"ip": "1.1.1.1"}]
+    submitted = [{"ip": "1.1.1.1", "remove_password": False}]
+    assert "remove_password" not in device_config.merge_devices(existing, submitted)[0]
+
+
+def test_merge_preserves_unmanaged_fields():
+    existing = [
+        {"ip": "1.1.1.1", "fake": True, "firmware_info": {"version": "12.0.2"}, "future": 1}
+    ]
+    submitted = [{"ip": "1.1.1.1", "dns_name": "flur"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {
+            "ip": "1.1.1.1",
+            "fake": True,
+            "firmware_info": {"version": "12.0.2"},
+            "future": 1,
+            "dns_name": "flur",
+        }
+    ]
+
+
+def test_merge_deletes_a_device_absent_from_the_payload():
+    existing = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2"}]
+    submitted = [{"ip": "1.1.1.1"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
+
+
+def test_merge_treats_a_changed_ip_as_a_new_device():
+    """The password cannot follow an IP change — there is nothing to match on."""
+    existing = [{"ip": "1.1.1.1", "password": "secret", "fake": True}]
+    submitted = [{"ip": "9.9.9.9"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "9.9.9.9"}]
+
+
+def test_merge_adds_a_new_device():
+    existing = [{"ip": "1.1.1.1"}]
+    submitted = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2", "username": "admin"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1"},
+        {"ip": "2.2.2.2", "username": "admin"},
+    ]
+
+
+def test_merge_drops_a_managed_field_the_client_cleared():
+    existing = [{"ip": "1.1.1.1", "dns_name": "old", "timeout": 240}]
+    submitted = [{"ip": "1.1.1.1"}]
+    result = device_config.merge_devices(existing, submitted)
+    assert "dns_name" not in result[0], "a cleared managed field is removed"
+    assert "timeout" not in result[0]
+
+
+def test_merge_follows_the_submitted_order():
+    existing = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2"}]
+    submitted = [{"ip": "2.2.2.2"}, {"ip": "1.1.1.1"}]
+    assert [d["ip"] for d in device_config.merge_devices(existing, submitted)] == [
+        "2.2.2.2",
+        "1.1.1.1",
+    ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_device_config.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.tasmota.device_config' has no attribute 'merge_devices'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+MANAGED_FIELDS = ("ip", "username", "password", "dns_name", "timeout")
+
+
+def merge_devices(
+    existing: list[dict[str, Any]],
+    submitted: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge the editor's view over the configuration on disk.
+
+    The submitted list decides membership and order; a device missing from it is
+    deleted. Everything this module does not manage — ``fake``,
+    ``firmware_info``, fields a later version introduces — is carried over from
+    the existing entry, matched by IP. A password is only replaced when one is
+    submitted, and only removed on explicit request.
+    """
+    by_ip = {device.get("ip"): device for device in existing}
+    merged: list[dict[str, Any]] = []
+
+    for entry in submitted:
+        current = dict(by_ip.get(entry.get("ip"), {}))
+        remove_password = bool(entry.get("remove_password"))
+
+        for field in MANAGED_FIELDS:
+            if field == "password":
+                continue
+            if entry.get(field) not in (None, ""):
+                current[field] = entry[field]
+            else:
+                current.pop(field, None)
+
+        if entry.get("password"):
+            current["password"] = entry["password"]
+        elif remove_password:
+            current.pop("password", None)
+
+        current.pop("remove_password", None)
+        merged.append(current)
+
+    return merged
+```
+
+Note the `ip` field is in `MANAGED_FIELDS` and always present after validation,
+so the loop sets it from the submitted entry — which is what makes a changed IP
+produce a fresh device.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_device_config.py -v -o addopts=""`
+Expected: PASS (17 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/device_config.py tests/test_device_config.py
+git commit -m "feat(config): merge submitted devices over the existing configuration"
+```
+
+---
+
+### Task 3: Validation schema
+
+**Files:**
+- Modify: `app/tasmota/api.py`
+- Test: `tests/test_config_api.py`
+
+**Interfaces:**
+- Consumes: `is_valid_ip_address` from `app.tasmota.updater` (already imported in `api.py`; check the existing import block and add it there if missing).
+- Produces: `DeviceConfigSchema` (Marshmallow, `unknown = RAISE`), `validate_device_list(devices: list[dict]) -> list[str]` returning human-readable errors (empty when valid).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config_api.py
+"""Validation and API behaviour for the device-configuration editor."""
+import pytest
+
+from app.tasmota import api
+
+
+def test_schema_accepts_a_minimal_device():
+    assert api.DeviceConfigSchema().load({"ip": "192.168.8.191"}) == {"ip": "192.168.8.191"}
+
+
+def test_schema_accepts_every_managed_field():
+    payload = {
+        "ip": "192.168.8.191",
+        "username": "admin",
+        "password": "secret",
+        "dns_name": "flur",
+        "timeout": 240,
+        "remove_password": False,
+    }
+    assert api.DeviceConfigSchema().load(payload) == payload
+
+
+@pytest.mark.parametrize("field", ["fake", "firmware_info"])
+def test_schema_rejects_unsettable_fields(field):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": "192.168.8.191", field: True})
+
+
+@pytest.mark.parametrize("ip", ["not-an-ip", "127.0.0.1", "169.254.169.254", ""])
+def test_schema_rejects_bad_or_blocked_addresses(ip):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": ip})
+
+
+@pytest.mark.parametrize("timeout", [59, 601])
+def test_schema_rejects_out_of_range_timeouts(timeout):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": "192.168.8.191", "timeout": timeout})
+
+
+def test_validate_device_list_reports_duplicate_ips():
+    errors = api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.191"}])
+    assert any("192.168.8.191" in message for message in errors)
+
+
+def test_validate_device_list_accepts_distinct_devices():
+    assert api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.192"}]) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: FAIL — `AttributeError: module 'app.tasmota.api' has no attribute 'DeviceConfigSchema'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the imports in `app/tasmota/api.py` (check what is already imported from
+`app.tasmota.updater` and extend that line rather than adding a second import):
+
+```python
+from marshmallow import Schema, ValidationError, fields, validate, validates_schema
+from app.tasmota.updater import is_valid_ip_address
+```
+
+Then, next to the existing schemas:
+
+```python
+def _validate_device_ip(value: str) -> None:
+    """Reject anything is_valid_ip_address() rejects.
+
+    That function deliberately blocks loopback, link-local and the cloud
+    metadata address — the same block that keeps the update endpoints from
+    being turned into an SSRF primitive. The editor must not be a way around it.
+    """
+    if not is_valid_ip_address(value):
+        raise ValidationError(f"Not a usable device address: {value!r}")
+
+
+class DeviceConfigSchema(Schema):
+    """One device as the editor may submit it."""
+
+    ip = fields.String(required=True, validate=_validate_device_ip)
+    username = fields.String()
+    password = fields.String()
+    dns_name = fields.String()
+    timeout = fields.Integer(validate=validate.Range(min=60, max=600))
+    remove_password = fields.Boolean()
+
+    class Meta:
+        unknown = "raise"
+
+
+def validate_device_list(devices: list) -> list:
+    """List-level checks that a per-device schema cannot express."""
+    errors = []
+    seen = set()
+    for device in devices:
+        ip = device.get("ip")
+        if ip in seen:
+            errors.append(f"Duplicate device address: {ip}")
+        seen.add(ip)
+    return errors
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: PASS (13 tests)
+
+If `Meta.unknown = "raise"` does not reject unknown fields on your Marshmallow
+version, use `from marshmallow import RAISE` and `unknown = RAISE` — the string
+form is accepted from Marshmallow 3.0 onward, and this project pins
+`marshmallow>=4.0.1`, so it should work. Report which form you used.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/api.py tests/test_config_api.py
+git commit -m "feat(api): validate device-configuration payloads"
+```
+
+---
+
+### Task 4: `GET /api/config/devices`
+
+**Files:**
+- Modify: `app/tasmota/api.py`
+- Test: `tests/test_config_api.py`
+
+**Interfaces:**
+- Consumes: `device_config.is_writable`, `load_devices_from_file`.
+- Produces: `DeviceConfigResource` with a `get()` method, registered at `/api/config/devices`.
+
+The response must carry the **raw configured** fields. Do not resolve DNS names
+and do not reuse `DeviceListResource`'s enrichment — it overwrites `dns_name`
+with the IP when nothing resolves, which round-tripped would pollute the file.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_config_api.py
+from pathlib import Path
+
+
+@pytest.fixture
+def config_app(tmp_path, monkeypatch):
+    """A Flask test client whose devices file lives in a writable tmp dir."""
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text(
+        "devices:\n"
+        "- ip: 192.168.8.191\n"
+        "  username: admin\n"
+        "  password: secret\n"
+        "  fake: true\n"
+        "- ip: 192.168.8.192\n",
+        encoding="utf-8",
+    )
+    from server import create_app
+
+    # create_app() takes no arguments — the project's pattern is to construct it
+    # and then override config, exactly as tests/conftest.py's `app` fixture does.
+    application = create_app()
+    application.config.update({"TESTING": True, "DEVICES_FILE": str(devices_file)})
+    with application.test_client() as client:
+        with client.session_transaction() as session:
+            session["ui"] = True
+        yield client, devices_file
+
+
+def test_get_config_masks_the_password(config_app):
+    client, _ = config_app
+    payload = client.get("/api/config/devices").get_json()
+    first = payload["devices"][0]
+    assert first["has_password"] is True
+    assert "password" not in first
+    assert payload["devices"][1]["has_password"] is False
+
+
+def test_get_config_returns_raw_fields_without_dns_resolution(config_app):
+    client, _ = config_app
+    payload = client.get("/api/config/devices").get_json()
+    assert "dns_name" not in payload["devices"][1], (
+        "a device without a configured dns_name must not get one invented"
+    )
+
+
+def test_get_config_reports_writability_and_path(config_app):
+    client, devices_file = config_app
+    payload = client.get("/api/config/devices").get_json()
+    assert payload["writable"] is True
+    assert payload["devices_file"] == str(devices_file)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: FAIL — 404, the route does not exist yet.
+
+If the session-cookie trick in the fixture does not authenticate, read
+`server.py`'s `_require_api_auth` and use whatever it accepts (an `X-API-Key`
+header with `API_KEY` set in the app config is the alternative). Report what you
+used.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+class DeviceConfigResource(Resource):
+    """The device list as configuration — raw fields, editable.
+
+    Separate from DeviceListResource on purpose: that one is the operational
+    view and enriches its answer (masked password, resolved dns_name falling
+    back to the IP), which must never be written back to the file.
+    """
+
+    def get(self):
+        """
+        Get the raw device configuration
+        ---
+        tags:
+          - configuration
+        responses:
+          200:
+            description: Configured devices, passwords replaced by has_password
+        """
+        devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
+        devices = load_devices_from_file(str(devices_file))
+
+        exposed = []
+        for device in devices:
+            entry = {
+                field: device[field]
+                for field in ("ip", "username", "dns_name", "timeout")
+                if field in device
+            }
+            entry["has_password"] = bool(device.get("password"))
+            exposed.append(entry)
+
+        return jsonify({
+            "devices": exposed,
+            "writable": device_config.is_writable(devices_file),
+            "devices_file": str(devices_file),
+        })
+```
+
+Add `from pathlib import Path` and `from app.tasmota import device_config` to the
+imports, and register the route in `init_api`:
+
+```python
+    api.add_resource(DeviceConfigResource, '/api/config/devices')
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: PASS (16 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/api.py tests/test_config_api.py
+git commit -m "feat(api): expose the raw device configuration for editing"
+```
+
+---
+
+### Task 5: `PUT /api/config/devices`
+
+**Files:**
+- Modify: `app/tasmota/api.py`
+- Test: `tests/test_config_api.py`
+
+**Interfaces:**
+- Consumes: `DeviceConfigSchema`, `validate_device_list`, `device_config.merge_devices`, `device_config.write_devices`, `device_config.ConfigWriteError`.
+- Produces: a `put()` method on `DeviceConfigResource`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_config_api.py
+import yaml
+
+
+def test_put_writes_the_merged_list(config_app):
+    client, devices_file = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "username": "admin", "dns_name": "flur"},
+    ]})
+    assert response.status_code == 200
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert written == [{
+        "ip": "192.168.8.191", "username": "admin", "dns_name": "flur",
+        "password": "secret", "fake": True,
+    }], "password and fake survive; the second device was deleted"
+
+
+def test_put_rejects_a_non_json_body(config_app):
+    client, _ = config_app
+    assert client.put("/api/config/devices", data="devices: []").status_code == 415
+
+
+def test_put_rejects_an_invalid_device(config_app):
+    client, devices_file = config_app
+    before = devices_file.read_text(encoding="utf-8")
+    response = client.put("/api/config/devices", json={"devices": [{"ip": "127.0.0.1"}]})
+    assert response.status_code == 400
+    assert devices_file.read_text(encoding="utf-8") == before, "nothing is written on error"
+
+
+def test_put_rejects_duplicate_ips(config_app):
+    client, _ = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191"}, {"ip": "192.168.8.191"},
+    ]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_unknown_fields(config_app):
+    client, _ = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "fake": True},
+    ]})
+    assert response.status_code == 400
+
+
+def test_put_reports_an_unwritable_target(config_app, monkeypatch):
+    client, _ = config_app
+    monkeypatch.setattr(api.device_config, "is_writable", lambda target: False)
+    response = client.put("/api/config/devices", json={"devices": [{"ip": "192.168.8.191"}]})
+    assert response.status_code == 409
+    assert "mount" in response.get_json()["details"].lower()
+
+
+def test_put_never_echoes_a_password(config_app):
+    client, _ = config_app
+    payload = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "password": "brandnew"},
+    ]}).get_json()
+    assert "brandnew" not in str(payload)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: FAIL — 405, `put` is not defined on the resource.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+    def put(self):
+        """
+        Replace the device configuration
+        ---
+        tags:
+          - configuration
+        responses:
+          200:
+            description: The stored configuration after the write
+          400:
+            description: Validation failed
+          409:
+            description: The configuration file is not writable
+          415:
+            description: Body was not JSON
+        """
+        if not request.is_json:
+            return {'error': 'Unsupported Media Type',
+                    'details': 'Content-Type must be application/json'}, 415
+
+        body = request.get_json(silent=True) or {}
+        submitted = body.get('devices')
+        if not isinstance(submitted, list):
+            return {'error': 'Bad Request', 'details': "'devices' must be a list"}, 400
+
+        schema = DeviceConfigSchema()
+        cleaned = []
+        for index, entry in enumerate(submitted):
+            try:
+                cleaned.append(schema.load(entry))
+            except ValidationError as exc:
+                return {'error': 'Bad Request',
+                        'details': f"Device #{index + 1}: {exc.messages}"}, 400
+
+        list_errors = validate_device_list(cleaned)
+        if list_errors:
+            return {'error': 'Bad Request', 'details': '; '.join(list_errors)}, 400
+
+        devices_file = Path(current_app.config.get('DEVICES_FILE', 'devices.yaml'))
+        existing = load_devices_from_file(str(devices_file))
+        merged = device_config.merge_devices(existing, cleaned)
+
+        try:
+            device_config.write_devices(devices_file, merged)
+        except device_config.ConfigWriteError as exc:
+            return {'error': 'Conflict', 'details': str(exc)}, 409
+
+        current_app.logger.info("Device configuration updated: %d device(s)", len(merged))
+        return self.get()
+```
+
+`api.py` defines no module-level `logger`, so this uses Flask's
+`current_app.logger` rather than introducing one. Do not add a module logger for
+a single line.
+
+Returning `self.get()` means the response is the freshly read configuration with
+passwords masked — the client never sees a password echoed back, and it gets the
+authoritative state rather than its own submission.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_config_api.py -v -o addopts=""`
+Expected: PASS (23 tests)
+
+- [ ] **Step 5: Run the whole green core**
+
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+Expected: PASS, with no pre-existing test broken.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/tasmota/api.py tests/test_config_api.py
+git commit -m "feat(api): write the device configuration from the editor"
+```
+
+---
+
+### Task 6: The editor UI
+
+**Files:**
+- Create: `app/static/js/devices-editor.js`
+- Modify: `app/templates/index.html`
+
+**Interfaces:**
+- Consumes: `GET`/`PUT /api/config/devices`.
+- Produces: an Alpine component `devicesEditor()`.
+
+Kept in its own file: `app/static/js/app.js` is already 499 lines and owns the
+operational view. The editor is a separate concern with its own state.
+
+- [ ] **Step 1: Write the component**
+
+```javascript
+// app/static/js/devices-editor.js
+/**
+ * Devices editor — edits the configuration behind /api/config/devices.
+ *
+ * The password is write-only: the server never sends it, an empty field means
+ * "keep", and removal is explicit. Changing a device's IP makes it a new device,
+ * so its password cannot follow.
+ */
+function devicesEditor() {
+    return {
+        devices: [],
+        writable: true,
+        devicesFile: '',
+        loading: false,
+        saving: false,
+        error: '',
+        saved: false,
+
+        async init() {
+            await this.load();
+        },
+
+        async load() {
+            this.loading = true;
+            this.error = '';
+            try {
+                const response = await fetch('/api/config/devices');
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const payload = await response.json();
+                this.devices = payload.devices.map(device => ({
+                    ...device,
+                    password: '',
+                    remove_password: false,
+                }));
+                this.writable = payload.writable;
+                this.devicesFile = payload.devices_file;
+            } catch (err) {
+                this.error = `Konfiguration konnte nicht geladen werden: ${err.message}`;
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        addDevice() {
+            this.devices.push({
+                ip: '', username: '', dns_name: '', timeout: null,
+                password: '', has_password: false, remove_password: false,
+            });
+        },
+
+        removeDevice(index) {
+            const device = this.devices[index];
+            const label = device.dns_name || device.ip || 'dieses Gerät';
+            if (!confirm(`${label} aus der Konfiguration entfernen?`)) return;
+            this.devices.splice(index, 1);
+        },
+
+        clearPassword(device) {
+            device.remove_password = true;
+            device.password = '';
+            device.has_password = false;
+        },
+
+        _payload() {
+            return this.devices.map(device => {
+                const entry = { ip: (device.ip || '').trim() };
+                if (device.username) entry.username = device.username;
+                if (device.dns_name) entry.dns_name = device.dns_name;
+                if (device.timeout) entry.timeout = Number(device.timeout);
+                if (device.password) entry.password = device.password;
+                if (device.remove_password) entry.remove_password = true;
+                return entry;
+            });
+        },
+
+        async save() {
+            this.saving = true;
+            this.error = '';
+            this.saved = false;
+            try {
+                const response = await fetch('/api/config/devices', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ devices: this._payload() }),
+                });
+                const payload = await response.json();
+                if (!response.ok) {
+                    throw new Error(payload.details || `HTTP ${response.status}`);
+                }
+                this.devices = payload.devices.map(device => ({
+                    ...device, password: '', remove_password: false,
+                }));
+                this.saved = true;
+                setTimeout(() => { this.saved = false; }, 4000);
+            } catch (err) {
+                this.error = `Speichern fehlgeschlagen: ${err.message}`;
+            } finally {
+                this.saving = false;
+            }
+        },
+    };
+}
+```
+
+- [ ] **Step 2: Add the section to the template**
+
+In `app/templates/index.html`, add the script tag next to the existing one at the
+bottom:
+
+```html
+    <script src="{{ url_for('static', filename='js/devices-editor.js') }}"></script>
+```
+
+And add the editor section after the device list section (find the closing tag of
+the block containing `<template x-for="device in devices"` around line 117 and
+place this after that section):
+
+```html
+    <section class="section" x-data="devicesEditor()" x-init="init()">
+      <h2 class="title is-4">Geräte verwalten</h2>
+
+      <div class="notification is-warning" x-show="!writable" x-cloak>
+        Die Konfigurationsdatei <span x-text="devicesFile"></span> ist nicht
+        schreibbar. Wird sie als einzelne Datei ins Image gemountet, muss
+        stattdessen ihr Verzeichnis gemountet werden — siehe
+        <code>compose.example.yml</code>.
+      </div>
+
+      <div class="notification is-danger" x-show="error" x-cloak x-text="error"></div>
+      <div class="notification is-success" x-show="saved" x-cloak>Gespeichert.</div>
+
+      <table class="table is-fullwidth">
+        <thead>
+          <tr>
+            <th>IP</th><th>Name</th><th>Benutzer</th><th>Passwort</th>
+            <th>Timeout</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="(device, index) in devices" :key="index">
+            <tr>
+              <td><input class="input" type="text" x-model="device.ip"
+                         :disabled="!writable" placeholder="192.168.8.191"
+                         title="IP-Adresse des Geräts eintragen"></td>
+              <td><input class="input" type="text" x-model="device.dns_name"
+                         :disabled="!writable"
+                         title="Anzeigenamen für das Gerät eintragen"></td>
+              <td><input class="input" type="text" x-model="device.username"
+                         :disabled="!writable"
+                         title="Benutzernamen für die Geräte-Anmeldung eintragen"></td>
+              <td>
+                <input class="input" type="password" x-model="device.password"
+                       :disabled="!writable"
+                       :placeholder="device.has_password ? '•••••••• (gesetzt)' : 'kein Passwort'"
+                       title="Neues Passwort eintragen — leer lassen behält das gespeicherte">
+                <button class="button is-small is-text" type="button"
+                        x-show="device.has_password" :disabled="!writable"
+                        @click="clearPassword(device)"
+                        title="Gespeichertes Passwort entfernen — das Gerät wird danach ohne Anmeldung angesprochen">
+                  Passwort entfernen
+                </button>
+              </td>
+              <td><input class="input" type="number" x-model="device.timeout"
+                         :disabled="!writable" min="60" max="600" placeholder="240"
+                         title="Timeout in Sekunden für dieses Gerät setzen (60–600)"></td>
+              <td>
+                <button class="button is-danger is-small" type="button"
+                        :disabled="!writable" @click="removeDevice(index)"
+                        title="Gerät aus der Konfiguration entfernen — wird erst beim Speichern wirksam">
+                  Entfernen
+                </button>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+
+      <div class="buttons">
+        <button class="button" type="button" :disabled="!writable" @click="addDevice()"
+                title="Neues Gerät zur Liste hinzufügen">Gerät hinzufügen</button>
+        <button class="button is-primary" type="button"
+                :disabled="!writable || saving" :class="{'is-loading': saving}"
+                @click="save()"
+                title="Geänderte Geräteliste in die Konfigurationsdatei schreiben">
+          Speichern
+        </button>
+      </div>
+    </section>
+```
+
+- [ ] **Step 3: Verify by hand against fake devices**
+
+Run: `ENV_FILE=.env.dev python server.py` and open `http://localhost:5001`.
+
+Check, and put the result in your report: the table lists the four fake devices;
+the password field shows the `•••••••• (gesetzt)` placeholder and not a value;
+adding a device, saving, and reloading the page keeps the change; and
+`devices-dev.yaml` still contains `fake: true` and the `firmware_info` blocks
+afterwards.
+
+Restore `devices-dev.yaml` with `git checkout devices-dev.yaml` when you are
+done, and say in the report that you did.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/static/js/devices-editor.js app/templates/index.html
+git commit -m "feat(ui): add the devices editor"
+```
+
+---
+
+### Task 7: End-to-end test
+
+**Files:**
+- Create: `tests/e2e/test_devices_editor.py`
+
+**Interfaces:**
+- Consumes: the finished editor.
+
+**The trap this task exists to avoid:** `tests/e2e/conftest.py`'s `app_server`
+fixture is **session-scoped** and runs against the repository's real
+`devices-dev.yaml`. An editor test using it would rewrite that file and corrupt
+every other e2e test in the same session. This test therefore starts its own app
+instance against a **copy** in a tmp directory.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/e2e/test_devices_editor.py
+"""The devices editor, against its own app instance on a copy of the fixture.
+
+Deliberately not using the shared `app_server` fixture: it is session-scoped and
+points at the repository's devices-dev.yaml, which this test would rewrite.
+"""
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def editable_app(tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    shutil.copy(REPO_ROOT / "devices-dev.yaml", devices_file)
+
+    port = _free_port()
+    env = {**os.environ, "DEVICES_FILE": str(devices_file), "PORT": str(port),
+           "HOST": "127.0.0.1"}
+    proc = subprocess.Popen(
+        [sys.executable, "server.py"], cwd=str(REPO_ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 25
+    try:
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(f"{base_url}/health", timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.3)
+        else:
+            raise RuntimeError("app did not become healthy")
+        yield base_url, devices_file
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_editor_persists_a_new_device(page, editable_app):
+    base_url, devices_file = editable_app
+    page.goto(base_url)
+
+    page.get_by_title("Neues Gerät zur Liste hinzufügen").click()
+    page.get_by_title("IP-Adresse des Geräts eintragen").last.fill("192.168.100.199")
+    page.get_by_title("Geänderte Geräteliste in die Konfigurationsdatei schreiben").click()
+
+    page.get_by_text("Gespeichert.").wait_for(state="visible", timeout=10000)
+
+    import yaml
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert any(device["ip"] == "192.168.100.199" for device in written)
+    assert any(device.get("fake") for device in written), "fake devices survived the write"
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest tests/e2e/test_devices_editor.py -m e2e -o addopts=""`
+Expected: PASS. If the selectors do not match what Task 6 produced, fix the
+selectors — not the UI — unless the UI is genuinely missing a tooltip the plan
+requires.
+
+- [ ] **Step 3: Confirm the repository fixture is untouched**
+
+Run: `git status --short devices-dev.yaml`
+Expected: no output. If the file changed, the test used the wrong app instance.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/test_devices_editor.py
+git commit -m "test(e2e): cover the devices editor round trip"
+```
+
+---
+
+### Task 8: Deployment change and documentation
+
+**Files:**
+- Modify: `compose.example.yml`
+- Modify: `docs/configuration.md`, `docs/container-setup.md`, `README.md`
+
+- [ ] **Step 1: Switch the mount**
+
+In `compose.example.yml`, replace the single-file mount (line 18,
+`- ./devices.yaml:/app/devices.yaml`) with a directory mount, and point
+`DEVICES_FILE` at it:
+
+```yaml
+      # The directory is mounted, not the file: replacing a bind-mounted file
+      # fails with EBUSY, so the editor could not write it.
+      - ./config:/app/config
+```
+
+and in the environment block:
+
+```yaml
+      - DEVICES_FILE=${DEVICES_FILE:-/app/config/devices.yaml}
+```
+
+- [ ] **Step 2: Document the editor and the migration**
+
+In `docs/configuration.md`, add a section on editing devices in the UI covering:
+what the editor manages, that the password is write-only and an empty field
+keeps the stored one, that changing a device's IP means the password must be
+entered again, that comments in the YAML are lost when the UI saves, and that
+one backup generation is kept as `devices.yaml.bak`.
+
+In `docs/container-setup.md` and `README.md`, update every place showing the
+old `-v ./devices.yaml:/app/devices.yaml` form, and add a short migration note:
+existing deployments must move the file into a directory and mount that,
+otherwise the editor stays read-only and says so.
+
+Run `grep -rn "devices.yaml:/app" README.md docs/ compose.example.yml` and fix
+every hit.
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -c '^```' README.md` — must be even (project rule).
+Run: `uv run --with mkdocs-material mkdocs build --strict`, then delete `site/`
+and any `uv.lock`.
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add compose.example.yml docs README.md
+git commit -m "docs(editor): document the devices editor and the mount migration"
+```
+
+---
+
+## Opening the pull request
+
+PR title: `feat(editor): manage devices from the web UI`. The `feat` type gives a
+minor bump, which a new interface warrants.
+
+The PR body must state the breaking deployment change prominently — existing
+deployments that bind-mount `devices.yaml` directly keep working read-only, and
+the editor tells them why — and name the two accepted risks: last writer wins
+with no conflict detection, and device passwords remain in plain text in the
+file, now reachable through an HTTP write path on a LAN without TLS (#74).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ The application supports the following environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SECRET_KEY` | Secret key for Flask sessions | `dev` |
-| `DEVICES_FILE` | Path to the devices configuration file | `devices.yaml` |
+| `DEVICES_FILE` | Path to the devices configuration file | `devices.yaml` (bare metal); `/app/config/devices.yaml` (container image default — see [Container Setup](container-setup.md)) |
 | `LOG_LEVEL` | Logging level | `INFO` |
 | `LOG_FILE` | Path to the log file | `logs/tasmota_updater.log` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,32 @@ devices:
 - `username`: Username for authentication (if the device requires it)
 - `password`: Password for authentication (if the device requires it)
 
+## Editing Devices in the Web UI
+
+The web interface includes a devices editor (under "Manage Devices") that reads and writes
+`devices.yaml` directly — no need to edit the file by hand or restart the app. It manages the
+same fields as the YAML file: `ip`, `dns_name`, `username`, `password` and `timeout`. Fields the
+editor does not manage (such as `fake` and cached `firmware_info`) are preserved as-is.
+
+A few behaviours are easy to miss:
+
+- **The password field is write-only.** The server never sends stored passwords back to the
+  browser, so the field always starts empty. Leave it blank and save to keep the existing
+  password; use "Remove password" to delete it explicitly.
+- **Changing a device's IP address creates a new device.** The editor matches existing entries by
+  IP to know which stored password belongs to which device. If you change the IP, the password is
+  not carried over — enter it again after the IP change.
+- **Comments in `devices.yaml` are lost when the UI saves.** The editor rewrites the whole file
+  from its in-memory model, so any hand-written comments in the YAML will not survive a save made
+  through the web UI.
+- **One backup generation is kept.** Every save copies the previous file to `devices.yaml.bak`
+  before writing the new one, so only the file from immediately before the last save is
+  recoverable — each subsequent save overwrites that backup in turn.
+- **The editor can be read-only.** If `devices.yaml` is bind-mounted into the container as a
+  single file rather than as part of a mounted directory, the file cannot be replaced atomically
+  (`EBUSY`) and the editor disables itself with an explanation. See
+  [Container Setup](container-setup.md) for the directory-mount migration.
+
 ## Environment Variables
 
 The application supports the following environment variables:

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -37,7 +37,7 @@ docker pull dodjango/tasmota-updater:latest
 
 # Run the container
 docker run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater dodjango/tasmota-updater:latest
 ```
@@ -50,12 +50,21 @@ docker pull ghcr.io/dodjango/tasmota-updater:latest
 
 # Run the container
 docker run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater ghcr.io/dodjango/tasmota-updater:latest
 ```
 
-> **Note:** You'll need to create a `devices.yaml` file in your current directory before running the container. See the [Configuration Options](configuration.md) documentation for details.
+> **Note:** You'll need a `devices.yaml` file in a `config` directory next to
+> the container (e.g. `./config/devices.yaml`) before running it. See the
+> [Configuration Options](configuration.md) documentation for details.
+>
+> **Migrating from an older version?** If you used to bind-mount
+> `devices.yaml` directly (`-v $(pwd)/devices.yaml:/app/devices.yaml`), it
+> still works — but the web UI's device editor stays read-only and says so,
+> because replacing a bind-mounted *file* fails with `EBUSY`. Move
+> `devices.yaml` into a directory and mount that directory instead, as shown
+> above, and point `DEVICES_FILE` at the new path.
 
 ## Manual Container Setup
 
@@ -69,7 +78,7 @@ docker build -f Containerfile -t tasmota-updater .
 
 # Run the container
 docker run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater tasmota-updater
 ```
@@ -82,7 +91,7 @@ podman build -f Containerfile -t tasmota-updater .
 
 # Run the container
 podman run -d -p 5001:5001 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml:Z \
+  -v $(pwd)/config:/app/config:Z \
   -v $(pwd)/logs:/app/logs:Z \
   --name tasmota-updater tasmota-updater
 ```
@@ -98,7 +107,7 @@ environment:
   - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
   - PORT=5001
   - HOST=0.0.0.0
-  - DEVICES_FILE=${DEVICES_FILE:-devices.yaml}
+  - DEVICES_FILE=${DEVICES_FILE:-/app/config/devices.yaml}
   - GUNICORN_WORKERS=${GUNICORN_WORKERS:-4}
   - ENV_FILE=
 ```
@@ -130,7 +139,10 @@ Recommendation:
 
 The container setup includes two volumes:
 
-- `./devices.yaml:/app/devices.yaml` - Maps your local devices configuration file into the container
+- `./config:/app/config` - Maps a local directory holding `devices.yaml` into the container. The
+  *directory* is mounted, not the file, so the built-in devices editor can replace the file
+  atomically when you save changes in the UI — replacing a bind-mounted single file fails with
+  `EBUSY`.
 - `./logs:/app/logs` - Maps the logs directory to persist logs outside the container
 
 You can add additional volumes as needed for your specific use case.
@@ -142,7 +154,7 @@ For production deployments, the container uses Gunicorn as the WSGI server. You 
 ```bash
 docker run -d -p 5001:5001 \
   -e GUNICORN_WORKERS=8 \
-  -v $(pwd)/devices.yaml:/app/devices.yaml \
+  -v $(pwd)/config:/app/config \
   -v $(pwd)/logs:/app/logs \
   --name tasmota-updater tasmota-updater
 ```

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -56,15 +56,19 @@ docker run -d -p 5001:5001 \
 ```
 
 > **Note:** You'll need a `devices.yaml` file in a `config` directory next to
-> the container (e.g. `./config/devices.yaml`) before running it. See the
-> [Configuration Options](configuration.md) documentation for details.
+> the container (e.g. `./config/devices.yaml`) before running it. The image
+> looks for it at `/app/config/devices.yaml` by default — matching the mount
+> shown above — so no `DEVICES_FILE` setting is needed unless you use a
+> different path. See the [Configuration Options](configuration.md)
+> documentation for details.
 >
 > **Migrating from an older version?** If you used to bind-mount
 > `devices.yaml` directly (`-v $(pwd)/devices.yaml:/app/devices.yaml`), it
 > still works — but the web UI's device editor stays read-only and says so,
 > because replacing a bind-mounted *file* fails with `EBUSY`. Move
 > `devices.yaml` into a directory and mount that directory instead, as shown
-> above, and point `DEVICES_FILE` at the new path.
+> above; the default `DEVICES_FILE` already expects it there, so only set
+> that variable yourself if you choose a different path.
 
 ## Manual Container Setup
 

--- a/tests/e2e/test_devices_editor.py
+++ b/tests/e2e/test_devices_editor.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from playwright.sync_api import expect
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -70,6 +71,7 @@ def test_editor_persists_a_new_device(page, editable_app):
     page.get_by_title("Write the changed device list to the configuration file").click()
 
     page.get_by_text("Saved.").wait_for(state="visible", timeout=10000)
+    expect(page.get_by_test_id("editor-error")).not_to_be_visible()
 
     written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
     assert any(device["ip"] == "192.168.100.199" for device in written)

--- a/tests/e2e/test_devices_editor.py
+++ b/tests/e2e/test_devices_editor.py
@@ -74,3 +74,69 @@ def test_editor_persists_a_new_device(page, editable_app):
     written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
     assert any(device["ip"] == "192.168.100.199" for device in written)
     assert any(device.get("fake") for device in written), "fake devices survived the write"
+
+
+def _row_for_ip(page, ip_field_title, ip):
+    """The table has no stable per-row id — find the <tr> by its IP input's
+    current value instead of relying on row order, which changing state can
+    shuffle.
+    """
+    inputs = page.get_by_title(ip_field_title)
+    for index in range(inputs.count()):
+        candidate = inputs.nth(index)
+        if candidate.input_value() == ip:
+            return candidate.locator("xpath=ancestor::tr[1]")
+    raise AssertionError(f"no row found for ip {ip!r}")
+
+
+def test_editor_round_trip_add_edit_reload_delete(page, editable_app):
+    """Add a device, save, reload, confirm it survived, edit its name, save,
+    delete it, save, reload, confirm it is gone — the round trip the design
+    asked for, beyond the single add-and-save the other test covers.
+    """
+    base_url, devices_file = editable_app
+    ip_field_title = (
+        "Enter the device's IP address — changing it makes this a new device, "
+        "so its stored password is not carried over"
+    )
+    name_field_title = "Enter a display name for the device"
+    save_title = "Write the changed device list to the configuration file"
+
+    page.goto(base_url)
+    page.get_by_title("Add a new device to the list").click()
+    page.get_by_title(ip_field_title).last.fill("192.168.100.222")
+    page.get_by_title(save_title).click()
+    page.get_by_text("Saved.").wait_for(state="visible", timeout=10000)
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert any(device["ip"] == "192.168.100.222" for device in written)
+
+    page.reload()
+    page.get_by_title(save_title).wait_for(state="visible", timeout=10000)
+    row = _row_for_ip(page, ip_field_title, "192.168.100.222")
+    row.get_by_title(name_field_title).fill("Round Trip Device")
+    page.get_by_title(save_title).click()
+    page.get_by_text("Saved.").wait_for(state="visible", timeout=10000)
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    edited = next(device for device in written if device["ip"] == "192.168.100.222")
+    assert edited["dns_name"] == "Round Trip Device"
+
+    page.reload()
+    page.get_by_title(save_title).wait_for(state="visible", timeout=10000)
+    row = _row_for_ip(page, ip_field_title, "192.168.100.222")
+    page.once("dialog", lambda dialog: dialog.accept())  # removeDevice()'s confirm()
+    row.get_by_title(
+        "Remove the device from the configuration — applied when you save"
+    ).click()
+    page.get_by_title(save_title).click()
+    page.get_by_text("Saved.").wait_for(state="visible", timeout=10000)
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert not any(device["ip"] == "192.168.100.222" for device in written)
+
+    page.reload()
+    page.get_by_title(save_title).wait_for(state="visible", timeout=10000)
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert not any(device["ip"] == "192.168.100.222" for device in written)
+    assert any(device.get("fake") for device in written), "fake devices survived the round trip"

--- a/tests/e2e/test_devices_editor.py
+++ b/tests/e2e/test_devices_editor.py
@@ -1,0 +1,76 @@
+"""The devices editor, against its own app instance on a copy of the fixture.
+
+Deliberately not using the shared `app_server` fixture: it is session-scoped and
+points at the repository's devices-dev.yaml, which this test would rewrite.
+"""
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.e2e
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def editable_app(tmp_path):
+    devices_file = tmp_path / "devices.yaml"
+    shutil.copy(REPO_ROOT / "devices-dev.yaml", devices_file)
+
+    port = _free_port()
+    env = {**os.environ, "DEVICES_FILE": str(devices_file), "PORT": str(port),
+           "HOST": "127.0.0.1"}
+    proc = subprocess.Popen(
+        [sys.executable, "server.py"], cwd=str(REPO_ROOT), env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 25
+    try:
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(f"{base_url}/health", timeout=1):
+                    break
+            except OSError:
+                time.sleep(0.3)
+        else:
+            raise RuntimeError("app did not become healthy")
+        yield base_url, devices_file
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_editor_persists_a_new_device(page, editable_app):
+    base_url, devices_file = editable_app
+    page.goto(base_url)
+
+    page.get_by_title("Add a new device to the list").click()
+    page.get_by_title(
+        "Enter the device's IP address — changing it makes this a new device, "
+        "so its stored password is not carried over"
+    ).last.fill("192.168.100.199")
+    page.get_by_title("Write the changed device list to the configuration file").click()
+
+    page.get_by_text("Saved.").wait_for(state="visible", timeout=10000)
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert any(device["ip"] == "192.168.100.199" for device in written)
+    assert any(device.get("fake") for device in written), "fake devices survived the write"

--- a/tests/e2e/test_update_flow.py
+++ b/tests/e2e/test_update_flow.py
@@ -22,4 +22,4 @@ def test_check_all_async_flow(page: Page, app_server: str):
     expect(page.get_by_text("Last:").first).to_be_visible(timeout=30000)
 
     # No error notification surfaced during the async flow.
-    expect(page.locator(".notification.is-danger")).not_to_be_visible()
+    expect(page.get_by_test_id("device-error")).not_to_be_visible()

--- a/tests/test_auth_gate.py
+++ b/tests/test_auth_gate.py
@@ -3,6 +3,8 @@
 Exercises the fail-closed gate via the Flask test client: no auth → 401,
 UI session cookie → allowed, X-API-Key → allowed, non-JSON state change → 415.
 """
+from pathlib import Path
+
 import pytest
 
 from server import create_app
@@ -39,6 +41,21 @@ def test_state_change_requires_json(client):
     resp = client.post("/api/update/all", data="check_only=true",
                        content_type="application/x-www-form-urlencoded")
     assert resp.status_code == 415
+
+
+def test_config_put_blocked_without_session_or_key(app, client):
+    """Anonymous PUT to the config-editor endpoint is rejected and writes nothing.
+
+    This is the endpoint that rewrites devices.yaml, so the fail-closed gate
+    matters here even more than on the read-only device list.
+    """
+    devices_file = Path(app.config["DEVICES_FILE"])
+    before = devices_file.read_text(encoding="utf-8")
+
+    resp = client.put("/api/config/devices", json={"devices": [{"ip": "192.168.8.191"}]})
+
+    assert resp.status_code == 401
+    assert devices_file.read_text(encoding="utf-8") == before
 
 
 def test_health_and_version_not_gated(client):

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -105,3 +105,65 @@ def test_get_config_reports_writability_and_path(config_app):
     payload = client.get("/api/config/devices").get_json()
     assert payload["writable"] is True
     assert payload["devices_file"] == str(devices_file)
+
+
+import yaml
+
+
+def test_put_writes_the_merged_list(config_app):
+    client, devices_file = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "username": "admin", "dns_name": "flur"},
+    ]})
+    assert response.status_code == 200
+
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert written == [{
+        "ip": "192.168.8.191", "username": "admin", "dns_name": "flur",
+        "password": "secret", "fake": True,
+    }], "password and fake survive; the second device was deleted"
+
+
+def test_put_rejects_a_non_json_body(config_app):
+    client, _ = config_app
+    assert client.put("/api/config/devices", data="devices: []").status_code == 415
+
+
+def test_put_rejects_an_invalid_device(config_app):
+    client, devices_file = config_app
+    before = devices_file.read_text(encoding="utf-8")
+    response = client.put("/api/config/devices", json={"devices": [{"ip": "127.0.0.1"}]})
+    assert response.status_code == 400
+    assert devices_file.read_text(encoding="utf-8") == before, "nothing is written on error"
+
+
+def test_put_rejects_duplicate_ips(config_app):
+    client, _ = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191"}, {"ip": "192.168.8.191"},
+    ]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_unknown_fields(config_app):
+    client, _ = config_app
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "fake": True},
+    ]})
+    assert response.status_code == 400
+
+
+def test_put_reports_an_unwritable_target(config_app, monkeypatch):
+    client, _ = config_app
+    monkeypatch.setattr(api.device_config, "is_writable", lambda target: False)
+    response = client.put("/api/config/devices", json={"devices": [{"ip": "192.168.8.191"}]})
+    assert response.status_code == 409
+    assert "mount" in response.get_json()["details"].lower()
+
+
+def test_put_never_echoes_a_password(config_app):
+    client, _ = config_app
+    payload = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191", "password": "brandnew"},
+    ]}).get_json()
+    assert "brandnew" not in str(payload)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -190,6 +190,17 @@ def test_put_accepts_an_empty_device_list_on_disk(config_app):
     assert written == [{"ip": "192.168.8.191"}]
 
 
+def test_put_accepts_an_empty_device_list_from_the_client(config_app):
+    """The server must not refuse `{"devices": []}` — deleting the last device is
+    a legitimate request. The client-side guard against an accidentally-empty
+    save (a failed load followed by Save) lives in devices-editor.js, not here.
+    """
+    client, devices_file = config_app
+    response = client.put("/api/config/devices", json={"devices": []})
+    assert response.status_code == 200
+    assert yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"] == []
+
+
 def test_put_accepts_a_missing_devices_file(config_app):
     client, devices_file = config_app
     devices_file.unlink()

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,5 +1,6 @@
 """Validation and API behaviour for the device-configuration editor."""
 import pytest
+import yaml
 
 from app.tasmota import api
 
@@ -53,11 +54,8 @@ def test_validate_device_list_accepts_distinct_devices():
     assert api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.192"}]) == []
 
 
-from pathlib import Path
-
-
 @pytest.fixture
-def config_app(tmp_path, monkeypatch):
+def config_app(tmp_path):
     """A Flask test client whose devices file lives in a writable tmp dir."""
     devices_file = tmp_path / "devices.yaml"
     devices_file.write_text(
@@ -105,9 +103,6 @@ def test_get_config_reports_writability_and_path(config_app):
     payload = client.get("/api/config/devices").get_json()
     assert payload["writable"] is True
     assert payload["devices_file"] == str(devices_file)
-
-
-import yaml
 
 
 def test_put_writes_the_merged_list(config_app):
@@ -167,3 +162,42 @@ def test_put_never_echoes_a_password(config_app):
         {"ip": "192.168.8.191", "password": "brandnew"},
     ]}).get_json()
     assert "brandnew" not in str(payload)
+
+
+def test_put_refuses_to_merge_over_unparsable_yaml(config_app):
+    client, devices_file = config_app
+    devices_file.write_text("devices:\n  - ip: [unterminated\n", encoding="utf-8")
+    before = devices_file.read_text(encoding="utf-8")
+
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191"},
+    ]})
+
+    assert response.status_code == 409
+    assert devices_file.read_text(encoding="utf-8") == before, "nothing is written on error"
+
+
+def test_put_accepts_an_empty_device_list_on_disk(config_app):
+    client, devices_file = config_app
+    devices_file.write_text("devices: []\n", encoding="utf-8")
+
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191"},
+    ]})
+
+    assert response.status_code == 200
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert written == [{"ip": "192.168.8.191"}]
+
+
+def test_put_accepts_a_missing_devices_file(config_app):
+    client, devices_file = config_app
+    devices_file.unlink()
+
+    response = client.put("/api/config/devices", json={"devices": [
+        {"ip": "192.168.8.191"},
+    ]})
+
+    assert response.status_code == 200
+    written = yaml.safe_load(devices_file.read_text(encoding="utf-8"))["devices"]
+    assert written == [{"ip": "192.168.8.191"}]

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -51,3 +51,57 @@ def test_validate_device_list_reports_duplicate_ips():
 
 def test_validate_device_list_accepts_distinct_devices():
     assert api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.192"}]) == []
+
+
+from pathlib import Path
+
+
+@pytest.fixture
+def config_app(tmp_path, monkeypatch):
+    """A Flask test client whose devices file lives in a writable tmp dir."""
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text(
+        "devices:\n"
+        "- ip: 192.168.8.191\n"
+        "  username: admin\n"
+        "  password: secret\n"
+        "  fake: true\n"
+        "- ip: 192.168.8.192\n",
+        encoding="utf-8",
+    )
+    from server import create_app
+
+    # create_app() takes no arguments — the project's pattern is to construct it
+    # and then override config, exactly as tests/conftest.py's `app` fixture does.
+    application = create_app()
+    application.config.update({"TESTING": True, "DEVICES_FILE": str(devices_file)})
+    with application.test_client() as client:
+        with client.session_transaction() as session:
+            # server.py's _require_api_auth() checks the `ui_authenticated` key,
+            # not `ui` — matching that name here.
+            session["ui_authenticated"] = True
+        yield client, devices_file
+
+
+def test_get_config_masks_the_password(config_app):
+    client, _ = config_app
+    payload = client.get("/api/config/devices").get_json()
+    first = payload["devices"][0]
+    assert first["has_password"] is True
+    assert "password" not in first
+    assert payload["devices"][1]["has_password"] is False
+
+
+def test_get_config_returns_raw_fields_without_dns_resolution(config_app):
+    client, _ = config_app
+    payload = client.get("/api/config/devices").get_json()
+    assert "dns_name" not in payload["devices"][1], (
+        "a device without a configured dns_name must not get one invented"
+    )
+
+
+def test_get_config_reports_writability_and_path(config_app):
+    client, devices_file = config_app
+    payload = client.get("/api/config/devices").get_json()
+    assert payload["writable"] is True
+    assert payload["devices_file"] == str(devices_file)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,0 +1,53 @@
+"""Validation and API behaviour for the device-configuration editor."""
+import pytest
+
+from app.tasmota import api
+
+
+def test_schema_accepts_a_minimal_device():
+    assert api.DeviceConfigSchema().load({"ip": "192.168.8.191"}) == {"ip": "192.168.8.191"}
+
+
+def test_schema_accepts_every_managed_field():
+    payload = {
+        "ip": "192.168.8.191",
+        "username": "admin",
+        "password": "secret",
+        "dns_name": "flur",
+        "timeout": 240,
+        "remove_password": False,
+    }
+    assert api.DeviceConfigSchema().load(payload) == payload
+
+
+@pytest.mark.parametrize("field", ["fake", "firmware_info"])
+def test_schema_rejects_unsettable_fields(field):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": "192.168.8.191", field: True})
+
+
+@pytest.mark.parametrize("ip", ["not-an-ip", "127.0.0.1", "169.254.169.254", ""])
+def test_schema_rejects_bad_or_blocked_addresses(ip):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": ip})
+
+
+@pytest.mark.parametrize("timeout", [59, 601])
+def test_schema_rejects_out_of_range_timeouts(timeout):
+    from marshmallow import ValidationError
+
+    with pytest.raises(ValidationError):
+        api.DeviceConfigSchema().load({"ip": "192.168.8.191", "timeout": timeout})
+
+
+def test_validate_device_list_reports_duplicate_ips():
+    errors = api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.191"}])
+    assert any("192.168.8.191" in message for message in errors)
+
+
+def test_validate_device_list_accepts_distinct_devices():
+    assert api.validate_device_list([{"ip": "192.168.8.191"}, {"ip": "192.168.8.192"}]) == []

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -97,3 +97,86 @@ def test_write_devices_cleans_up_on_backup_failure(tmp_path, monkeypatch):
 
     assert target.read_text(encoding="utf-8") == original_content
     assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml"]
+
+
+def test_merge_keeps_the_existing_password_when_none_is_submitted():
+    existing = [{"ip": "1.1.1.1", "password": "secret", "username": "admin"}]
+    submitted = [{"ip": "1.1.1.1", "username": "admin"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1", "username": "admin", "password": "secret"}
+    ]
+
+
+def test_merge_replaces_a_submitted_password():
+    existing = [{"ip": "1.1.1.1", "password": "old"}]
+    submitted = [{"ip": "1.1.1.1", "password": "new"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1", "password": "new"}
+    ]
+
+
+def test_merge_removes_the_password_on_request():
+    existing = [{"ip": "1.1.1.1", "password": "old"}]
+    submitted = [{"ip": "1.1.1.1", "remove_password": True}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
+
+
+def test_merge_never_writes_the_control_field():
+    existing = [{"ip": "1.1.1.1"}]
+    submitted = [{"ip": "1.1.1.1", "remove_password": False}]
+    assert "remove_password" not in device_config.merge_devices(existing, submitted)[0]
+
+
+def test_merge_preserves_unmanaged_fields():
+    existing = [
+        {"ip": "1.1.1.1", "fake": True, "firmware_info": {"version": "12.0.2"}, "future": 1}
+    ]
+    submitted = [{"ip": "1.1.1.1", "dns_name": "flur"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {
+            "ip": "1.1.1.1",
+            "fake": True,
+            "firmware_info": {"version": "12.0.2"},
+            "future": 1,
+            "dns_name": "flur",
+        }
+    ]
+
+
+def test_merge_deletes_a_device_absent_from_the_payload():
+    existing = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2"}]
+    submitted = [{"ip": "1.1.1.1"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
+
+
+def test_merge_treats_a_changed_ip_as_a_new_device():
+    """The password cannot follow an IP change — there is nothing to match on."""
+    existing = [{"ip": "1.1.1.1", "password": "secret", "fake": True}]
+    submitted = [{"ip": "9.9.9.9"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "9.9.9.9"}]
+
+
+def test_merge_adds_a_new_device():
+    existing = [{"ip": "1.1.1.1"}]
+    submitted = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2", "username": "admin"}]
+    assert device_config.merge_devices(existing, submitted) == [
+        {"ip": "1.1.1.1"},
+        {"ip": "2.2.2.2", "username": "admin"},
+    ]
+
+
+def test_merge_drops_a_managed_field_the_client_cleared():
+    existing = [{"ip": "1.1.1.1", "dns_name": "old", "timeout": 240}]
+    submitted = [{"ip": "1.1.1.1"}]
+    result = device_config.merge_devices(existing, submitted)
+    assert "dns_name" not in result[0], "a cleared managed field is removed"
+    assert "timeout" not in result[0]
+
+
+def test_merge_follows_the_submitted_order():
+    existing = [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2"}]
+    submitted = [{"ip": "2.2.2.2"}, {"ip": "1.1.1.1"}]
+    assert [d["ip"] for d in device_config.merge_devices(existing, submitted)] == [
+        "2.2.2.2",
+        "1.1.1.1",
+    ]

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -1,0 +1,64 @@
+"""Unit tests for reading, merging and writing the device configuration."""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.tasmota import device_config
+
+
+def test_is_writable_accepts_a_normal_file(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    assert device_config.is_writable(target) is True
+
+
+def test_is_writable_accepts_a_missing_file_in_a_writable_directory(tmp_path):
+    assert device_config.is_writable(tmp_path / "devices.yaml") is True
+
+
+def test_is_writable_rejects_an_unwritable_directory(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    tmp_path.chmod(0o500)
+    try:
+        assert device_config.is_writable(target) is False
+    finally:
+        tmp_path.chmod(0o700)
+
+
+def test_write_devices_replaces_the_file(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\n", encoding="utf-8")
+
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+
+    assert yaml.safe_load(target.read_text(encoding="utf-8")) == {"devices": [{"ip": "2.2.2.2"}]}
+
+
+def test_write_devices_keeps_one_backup_generation(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\n", encoding="utf-8")
+
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    device_config.write_devices(target, [{"ip": "3.3.3.3"}])
+
+    backup = yaml.safe_load((tmp_path / "devices.yaml.bak").read_text(encoding="utf-8"))
+    assert backup == {"devices": [{"ip": "2.2.2.2"}]}, "the backup holds the previous version"
+
+
+def test_write_devices_leaves_no_temp_file_behind(tmp_path):
+    target = tmp_path / "devices.yaml"
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml"]
+
+
+def test_write_devices_refuses_an_unwritable_target(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    tmp_path.chmod(0o500)
+    try:
+        with pytest.raises(device_config.ConfigWriteError):
+            device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+    finally:
+        tmp_path.chmod(0o700)

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -27,6 +27,49 @@ def test_is_writable_rejects_an_unwritable_directory(tmp_path):
         tmp_path.chmod(0o700)
 
 
+def test_read_devices_returns_empty_for_a_missing_file(tmp_path):
+    assert device_config.read_devices(tmp_path / "devices.yaml") == []
+
+
+def test_read_devices_returns_empty_for_an_empty_file(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("", encoding="utf-8")
+    assert device_config.read_devices(target) == []
+
+
+def test_read_devices_returns_empty_for_an_empty_device_list(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    assert device_config.read_devices(target) == []
+
+
+def test_read_devices_returns_the_configured_devices(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 192.168.8.191\n", encoding="utf-8")
+    assert device_config.read_devices(target) == [{"ip": "192.168.8.191"}]
+
+
+def test_read_devices_raises_on_invalid_yaml(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n  - ip: [unterminated\n", encoding="utf-8")
+    with pytest.raises(device_config.ConfigReadError):
+        device_config.read_devices(target)
+
+
+def test_read_devices_raises_when_devices_is_not_a_list(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: not-a-list\n", encoding="utf-8")
+    with pytest.raises(device_config.ConfigReadError):
+        device_config.read_devices(target)
+
+
+def test_read_devices_raises_when_the_document_is_not_a_mapping(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    with pytest.raises(device_config.ConfigReadError):
+        device_config.read_devices(target)
+
+
 def test_write_devices_replaces_the_file(tmp_path):
     target = tmp_path / "devices.yaml"
     target.write_text("devices:\n- ip: 1.1.1.1\n", encoding="utf-8")

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -122,9 +122,10 @@ def test_merge_removes_the_password_on_request():
 
 
 def test_merge_never_writes_the_control_field():
-    existing = [{"ip": "1.1.1.1"}]
-    submitted = [{"ip": "1.1.1.1", "remove_password": False}]
-    assert "remove_password" not in device_config.merge_devices(existing, submitted)[0]
+    """A stray control field in the file on disk must not survive the merge."""
+    existing = [{"ip": "1.1.1.1", "remove_password": True}]
+    submitted = [{"ip": "1.1.1.1"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
 
 
 def test_merge_preserves_unmanaged_fields():
@@ -180,3 +181,10 @@ def test_merge_follows_the_submitted_order():
         "2.2.2.2",
         "1.1.1.1",
     ]
+
+
+def test_merge_skips_entries_without_an_ip_on_either_side():
+    """An ip-less entry cannot be matched and must not leak another device's data."""
+    existing = [{"fake": True, "firmware_info": {"version": "12.0.2"}}, {"ip": "1.1.1.1"}]
+    submitted = [{}, {"ip": "1.1.1.1"}]
+    assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -1,10 +1,18 @@
 """Unit tests for reading, merging and writing the device configuration."""
+import os
+import stat
+import threading
+import time
 from pathlib import Path
 
 import pytest
 import yaml
 
 from app.tasmota import device_config
+
+# Root ignores the permission bits these tests exercise, which is exactly the
+# situation in a devcontainer — skip rather than fail there.
+skip_as_root = pytest.mark.skipif(os.geteuid() == 0, reason="root ignores permission bits")
 
 
 def test_is_writable_accepts_a_normal_file(tmp_path):
@@ -17,6 +25,7 @@ def test_is_writable_accepts_a_missing_file_in_a_writable_directory(tmp_path):
     assert device_config.is_writable(tmp_path / "devices.yaml") is True
 
 
+@skip_as_root
 def test_is_writable_rejects_an_unwritable_directory(tmp_path):
     target = tmp_path / "devices.yaml"
     target.write_text("devices: []\n", encoding="utf-8")
@@ -96,6 +105,7 @@ def test_write_devices_leaves_no_temp_file_behind(tmp_path):
     assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml"]
 
 
+@skip_as_root
 def test_write_devices_refuses_an_unwritable_target(tmp_path):
     target = tmp_path / "devices.yaml"
     target.write_text("devices: []\n", encoding="utf-8")
@@ -231,3 +241,109 @@ def test_merge_skips_entries_without_an_ip_on_either_side():
     existing = [{"fake": True, "firmware_info": {"version": "12.0.2"}}, {"ip": "1.1.1.1"}]
     submitted = [{}, {"ip": "1.1.1.1"}]
     assert device_config.merge_devices(existing, submitted) == [{"ip": "1.1.1.1"}]
+
+
+def test_read_document_returns_the_full_mapping(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\nother_key: keep-me\n", encoding="utf-8")
+    assert device_config.read_document(target) == {
+        "devices": [{"ip": "1.1.1.1"}],
+        "other_key": "keep-me",
+    }
+
+
+def test_read_document_returns_an_empty_mapping_for_a_missing_file(tmp_path):
+    assert device_config.read_document(tmp_path / "devices.yaml") == {}
+
+
+def test_write_devices_preserves_an_unmanaged_top_level_key(tmp_path):
+    """The document level must not lose a key it was never asked to touch —
+    matching the lengths merge_devices() already goes to for per-device fields.
+    """
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 1.1.1.1\nother_key: keep-me\n", encoding="utf-8")
+
+    document = device_config.read_document(target)
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}], document=document)
+
+    assert yaml.safe_load(target.read_text(encoding="utf-8")) == {
+        "devices": [{"ip": "2.2.2.2"}],
+        "other_key": "keep-me",
+    }
+
+
+def test_write_devices_matches_the_target_permissions(tmp_path):
+    """mkstemp() creates the temp file 0600; Path.replace() would otherwise carry
+    that onto the target, silently tightening it and locking out the SSH editing
+    path the design promises stays open.
+    """
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices: []\n", encoding="utf-8")
+    target.chmod(0o664)
+
+    device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o664
+
+
+def test_replace_devices_reads_merges_and_writes_under_lock(tmp_path):
+    target = tmp_path / "devices.yaml"
+    target.write_text(
+        "devices:\n- ip: 1.1.1.1\n  password: secret\nother_key: keep-me\n", encoding="utf-8"
+    )
+
+    merged = device_config.replace_devices(target, [{"ip": "1.1.1.1"}, {"ip": "2.2.2.2"}])
+
+    assert merged == [{"ip": "1.1.1.1", "password": "secret"}, {"ip": "2.2.2.2"}]
+    on_disk = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert on_disk["devices"] == merged
+    assert on_disk["other_key"] == "keep-me"
+
+
+def test_replace_devices_serialises_overlapping_writers(tmp_path):
+    """Two overlapping writers must not both read the same pre-edit state and
+    each write a `.bak` that clobbers the other's backup — the lock makes
+    read-merge-write one unit, so the second writer's backup is the first
+    writer's real result, and the original pre-edit state is never lost.
+
+    Verified here by forcing write_devices() to take a moment and recording
+    the [start, end) interval each call ran in: with the lock in place the two
+    intervals cannot overlap, no matter how the OS schedules the threads.
+    """
+    target = tmp_path / "devices.yaml"
+    target.write_text("devices:\n- ip: 0.0.0.0\n", encoding="utf-8")
+
+    intervals: list[tuple[float, float]] = []
+    intervals_lock = threading.Lock()
+    original_write_devices = device_config.write_devices
+
+    def slow_write_devices(path, devices, document=None):
+        start = time.monotonic()
+        time.sleep(0.05)
+        original_write_devices(path, devices, document=document)
+        end = time.monotonic()
+        with intervals_lock:
+            intervals.append((start, end))
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(device_config, "write_devices", slow_write_devices)
+        first = threading.Thread(
+            target=device_config.replace_devices, args=(target, [{"ip": "1.1.1.1"}])
+        )
+        second = threading.Thread(
+            target=device_config.replace_devices, args=(target, [{"ip": "2.2.2.2"}])
+        )
+        first.start()
+        second.start()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+    assert len(intervals) == 2, "both writers must have completed"
+    (start_a, end_a), (start_b, end_b) = intervals
+    assert end_a <= start_b or end_b <= start_a, "writes overlapped despite the lock"
+
+    on_disk = yaml.safe_load(target.read_text(encoding="utf-8"))
+    backup = yaml.safe_load((tmp_path / "devices.yaml.bak").read_text(encoding="utf-8"))
+    assert on_disk["devices"] in ([{"ip": "1.1.1.1"}], [{"ip": "2.2.2.2"}])
+    assert backup["devices"] in ([{"ip": "1.1.1.1"}], [{"ip": "2.2.2.2"}])
+    assert on_disk["devices"] != backup["devices"]

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -62,3 +62,38 @@ def test_write_devices_refuses_an_unwritable_target(tmp_path):
             device_config.write_devices(target, [{"ip": "2.2.2.2"}])
     finally:
         tmp_path.chmod(0o700)
+
+
+def test_write_devices_cleans_up_on_replace_failure(tmp_path, monkeypatch):
+    target = tmp_path / "devices.yaml"
+    original_content = "devices:\n- ip: 1.1.1.1\n"
+    target.write_text(original_content, encoding="utf-8")
+
+    def failing_replace(src, dst):
+        raise OSError("Mock replace failure")
+
+    monkeypatch.setattr(device_config.os, "replace", failing_replace)
+
+    with pytest.raises(device_config.ConfigWriteError):
+        device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+
+    assert target.read_text(encoding="utf-8") == original_content
+    # Backup is created before replace fails, so it exists
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml", "devices.yaml.bak"]
+
+
+def test_write_devices_cleans_up_on_backup_failure(tmp_path, monkeypatch):
+    target = tmp_path / "devices.yaml"
+    original_content = "devices:\n- ip: 1.1.1.1\n"
+    target.write_text(original_content, encoding="utf-8")
+
+    def failing_copy2(src, dst):
+        raise OSError("Mock copy2 failure")
+
+    monkeypatch.setattr(device_config.shutil, "copy2", failing_copy2)
+
+    with pytest.raises(device_config.ConfigWriteError):
+        device_config.write_devices(target, [{"ip": "2.2.2.2"}])
+
+    assert target.read_text(encoding="utf-8") == original_content
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["devices.yaml"]

--- a/tests/test_device_config.py
+++ b/tests/test_device_config.py
@@ -112,10 +112,10 @@ def test_write_devices_cleans_up_on_replace_failure(tmp_path, monkeypatch):
     original_content = "devices:\n- ip: 1.1.1.1\n"
     target.write_text(original_content, encoding="utf-8")
 
-    def failing_replace(src, dst):
+    def failing_replace(self, target):
         raise OSError("Mock replace failure")
 
-    monkeypatch.setattr(device_config.os, "replace", failing_replace)
+    monkeypatch.setattr(Path, "replace", failing_replace)
 
     with pytest.raises(device_config.ConfigWriteError):
         device_config.write_devices(target, [{"ip": "2.2.2.2"}])


### PR DESCRIPTION
Erster von zwei Zyklen zu #99. Die Geräteliste lässt sich jetzt im Browser pflegen, statt `devices.yaml` per SSH zu editieren. **Discovery folgt als eigener Zyklus** — der Editor ist die Voraussetzung dafür, dass gefundene Geräte irgendwo landen können.

Entwurf und Plan liegen im PR: [`2026-08-07-devices-editor-design.md`](docs/audit-2026-07/2026-08-07-devices-editor-design.md), [`-plan.md`](docs/audit-2026-07/2026-08-07-devices-editor-plan.md).

## ⚠️ Breaking Change am Deployment

Die Konfiguration wird jetzt als **Verzeichnis** gemountet, nicht als einzelne Datei:

```yaml
- ./config:/app/config          # statt ./devices.yaml:/app/devices.yaml
```

Grund: ein Bind-Mount auf eine Datei macht sie zum Mountpoint, und `rename()` darüber scheitert mit `EBUSY` — der atomare Schreibvorgang wäre unmöglich. Bestehende Deployments **laufen weiter**, der Editor bleibt dort aber schreibgeschützt und sagt genau das, statt still zu scheitern. Das Image setzt `DEVICES_FILE=/app/config/devices.yaml` als Default, der Mount allein genügt also.

## Die vier Entscheidungen, die den Entwurf tragen

| | |
|---|---|
| Wahrheit | **die YAML-Datei**, keine Datenbank; Handarbeit per SSH bleibt möglich |
| Gleichzeitige Änderungen | **letzter Schreiber gewinnt**, bewusst ohne Konflikterkennung — eine Backup-Generation als `.bak` macht sie wiederherstellbar |
| Passwörter | **nur schreibbar**: der Server sendet sie nie, leeres Feld heißt behalten, Entfernen ist explizit |
| Deployment | Verzeichnis-Mount, siehe oben |

## Warum eine eigene Ressource

`/api/devices` ist die operative Sicht und zum Editieren unbrauchbar: es maskiert das Passwort zu `'********'` und überschreibt `dns_name` mit dem aufgelösten Namen — oder, wenn keiner auflösbar ist, **mit der IP selbst**. Ein Round-Trip dieser Antwort schriebe `dns_name: 192.168.8.191` in jedes Gerät ohne Namen und zerstörte jedes Passwort. Der Editor bekommt deshalb `/api/config/devices` mit den rohen konfigurierten Feldern.

**Der Server schreibt nie, was der Client schickt.** Er liest, führt die verwalteten Felder über den bestehenden Eintrag (Identität ist die IP) und schreibt das Ergebnis. Damit überleben Passwort, `fake`, `firmware_info` und alles, was eine spätere Version einführt.

## Was die Reviews gefunden haben

Acht Tasks, jeder mit eigenem Review, dazu ein Abschluss-Review über den ganzen Branch. Die vier, die es wert sind, genannt zu werden — alle aus der Familie „etwas Unbekanntes als Feststellung ausgeben":

- **Ein fehlgeschlagenes Laden plus ein Klick auf Speichern hätte alles gelöscht.** Nach einem gescheiterten `GET` stand eine leere Tabelle mit aktivem Speichern-Knopf; ein Klick schickte `{"devices": []}` — eine völlig legale Anfrage — und die Datei war leer. Jetzt gibt es ein `loaded`-Gate und eine Rückfrage, bevor eine nicht-leere Liste geleert wird.
- **`load_devices_from_file()` beantwortet jeden Fehler mit `[]`.** Auf dem Schreibpfad hieße das: bei kurzzeitig unlesbarer Datei ist die Merge-Basis leer und der nächste Speichervorgang wirft jedes Passwort und jedes Fake-Fixture weg — mit der kaputten Datei im Backup. Der Schreibpfad hat jetzt einen **strikten** Reader, der wirft statt zu schweigen; der Lesepfad bleibt nachsichtig.
- **Die dokumentierte Container-Migration hätte ins Leere geschrieben.** Die `docker run`-Beispiele mounteten `config/`, setzten aber kein `DEVICES_FILE`, und das Image hatte keinen Default — die App hätte ein nicht gemountetes `/app/devices.yaml` gelesen und der Editor womöglich in die flüchtige Container-Schicht gespeichert.
- **Zwei gleichzeitige Schreibvorgänge** hätten auch den Vor-Zustand im `.bak` zerstört, nicht nur den unterlegenen Schreibvorgang. Das ist eine andere Situation als das bewusst akzeptierte SSH-gegen-UI; `read → merge → write` läuft jetzt unter einem Lock.

## Tests

135 im grünen Kern (+~60), plus ein e2e-Durchlauf über anlegen → speichern → neu laden → ändern → löschen. Der e2e-Test startet **eine eigene App-Instanz auf einer Kopie** von `devices-dev.yaml`: die gemeinsame Fixture ist session-scoped und zeigt auf die echte Datei im Repo, ein Editor-Test darüber hätte die übrigen e2e-Tests beschädigt.

## Entscheidungen, die ich allein getroffen habe

Der Betreiber war während der Umsetzung offline. Zwei Dinge sind daher meine Wahl und dürfen gern überstimmt werden:

- **Die Oberfläche ist englisch.** Mein Plan hatte deutschen Text vorgesehen; die Seite ist aber durchgehend englisch (`<html lang="en">`). Eine deutsche Insel darin wäre schlechter als beides einheitlich.
- **`--force`-artige Kernänderungen wurden nicht angefasst.** Der PR bleibt beim Versprechen, nur die Editier-Schicht zu liefern.

## Nicht abgedeckt

Klartext-Passwörter in der Datei bleiben, wie sie sind — der Editor verschlechtert das nicht, macht die Datei aber zum Ziel eines Schreibzugriffs über HTTP im LAN ohne TLS. Das gehört ins Threat-Model (#74). Es gibt außerdem kein Audit-Log darüber, wer wann was geändert hat.
