### PR TITLE
feat: find Tasmota devices on the network

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tasmota Remote Updater is a tool that automatically updates multiple Tasmota dev
 
 **Three supported interfaces in one tool:**
 
-- **Web Interface**: Modern dashboard with one-click updates and real-time monitoring
+- **Web Interface**: Modern dashboard with one-click updates and real-time monitoring, a built-in device editor, and network discovery to find Tasmota devices without hunting for IP addresses
 - **RESTful API**: Programmatic access with Swagger documentation
 - **Command-Line Interface**: A thin `python -m app.cli` wrapper for cron jobs and scripting — see [Command-Line Usage](docs/cli-usage.md)
 

--- a/app/static/js/devices-editor.js
+++ b/app/static/js/devices-editor.js
@@ -59,6 +59,35 @@ function devicesEditor() {
             });
         },
 
+        /**
+         * Take findings from the discovery modal as unsaved rows.
+         *
+         * Deliberately additive and deliberately unsaved: the user still has to
+         * add credentials and press Save, so PUT /api/config/devices remains the
+         * only path that writes the file.
+         *
+         * Gated on `loaded` for the same reason addDevice() is. Appending to a
+         * list that never loaded and saving it would submit those rows as the
+         * entire configuration and wipe everything else on disk.
+         */
+        adoptDiscovered(devices) {
+            if (!this.loaded || !this.writable) return;
+            const known = new Set(this.devices.map(device => (device.ip || '').trim()));
+            (devices || [])
+                .filter(device => device.ip && !known.has(device.ip))
+                .forEach(device => {
+                    this.devices.push({
+                        ip: device.ip,
+                        username: '',
+                        dns_name: device.dns_name || '',
+                        timeout: null,
+                        password: '',
+                        has_password: false,
+                        remove_password: false,
+                    });
+                });
+        },
+
         removeDevice(index) {
             const device = this.devices[index];
             const label = device.dns_name || device.ip || 'this device';

--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -1,0 +1,151 @@
+/**
+ * Find Tasmota devices on the network and hand the picks to the editor.
+ *
+ * This component never writes configuration. Adopted devices leave here as a
+ * `discovery-adopt` event and become unsaved rows in the editor, so the single
+ * save path through PUT /api/config/devices stays the only writer.
+ *
+ * The editor and this modal talk through window events in both directions
+ * rather than through $refs: they are separate x-data scopes, and reaching
+ * into another scope's methods by DOM reference breaks the moment the markup
+ * is nested differently.
+ */
+function discoveryModal() {
+    return {
+        isOpen: false,
+        method: null,          // 'mdns' | 'scan' while a job runs
+        network: '',
+        limits: { max_prefix: 22, max_hosts: 1024 },
+        jobId: null,
+        status: null,          // 'pending' | 'running' | 'completed' | 'error'
+        completed: 0,
+        total: null,
+        results: [],
+        selected: [],
+        notice: null,
+        error: null,
+        pollTimer: null,
+
+        async open() {
+            this.isOpen = true;
+            this.reset();
+            try {
+                const response = await fetch('/api/discovery');
+                if (response.ok) {
+                    const body = await response.json();
+                    this.limits = body.limits || this.limits;
+                    this.network = (body.suggested_networks || [])[0] || '';
+                }
+            } catch (err) {
+                // A missing suggestion is not worth an error banner — the user
+                // can type the network. Only a failed search is worth shouting about.
+            }
+        },
+
+        close() {
+            // Stops the polling, not the job. The server finishes on its own
+            // within ~25s; cancelling it would be extra state for nothing.
+            this.isOpen = false;
+            this.stopPolling();
+        },
+
+        reset() {
+            this.jobId = null;
+            this.status = null;
+            this.completed = 0;
+            this.total = null;
+            this.results = [];
+            this.selected = [];
+            this.notice = null;
+            this.error = null;
+        },
+
+        get isRunning() {
+            return this.status === 'pending' || this.status === 'running';
+        },
+
+        get progressLabel() {
+            if (this.method === 'mdns') return 'Listening for announcements…';
+            if (this.total) return `Probed ${this.completed} of ${this.total} addresses`;
+            return 'Starting…';
+        },
+
+        get selectableCount() {
+            return this.results.filter(device => !device.already_configured).length;
+        },
+
+        async start(method) {
+            this.reset();
+            this.method = method;
+            const payload = method === 'scan'
+                ? { method, network: this.network }
+                : { method };
+
+            try {
+                const response = await fetch('/api/discovery', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const body = await response.json();
+                if (!response.ok) {
+                    this.error = body.details || body.error || 'Discovery could not be started.';
+                    return;
+                }
+                this.jobId = body.job_id;
+                this.status = 'pending';
+                this.poll();
+            } catch (err) {
+                this.error = 'Discovery could not be started.';
+            }
+        },
+
+        poll() {
+            this.stopPolling();
+            this.pollTimer = setInterval(async () => {
+                try {
+                    const response = await fetch(`/api/jobs/${this.jobId}`);
+                    if (!response.ok) {
+                        this.error = 'Lost track of the discovery job.';
+                        this.stopPolling();
+                        return;
+                    }
+                    const job = await response.json();
+                    this.status = job.status;
+                    this.completed = job.completed || 0;
+                    this.total = job.total;
+                    this.results = job.results || [];
+                    this.notice = job.notice;
+                    if (job.status === 'completed' || job.status === 'error') {
+                        this.error = job.error;
+                        this.stopPolling();
+                    }
+                } catch (err) {
+                    this.error = 'Lost track of the discovery job.';
+                    this.stopPolling();
+                }
+            }, 1000);
+        },
+
+        stopPolling() {
+            if (this.pollTimer) {
+                clearInterval(this.pollTimer);
+                this.pollTimer = null;
+            }
+        },
+
+        toggle(ip) {
+            const index = this.selected.indexOf(ip);
+            if (index === -1) this.selected.push(ip);
+            else this.selected.splice(index, 1);
+        },
+
+        adopt() {
+            const picks = this.results
+                .filter(device => this.selected.includes(device.ip))
+                .map(device => ({ ip: device.ip, dns_name: device.hostname || '' }));
+            this.$dispatch('discovery-adopt', { devices: picks });
+            this.close();
+        },
+    };
+}

--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -50,6 +50,10 @@ function discoveryModal() {
         },
 
         reset() {
+            // Drop any timer first. Without this, re-opening the dialog while a
+            // poll is still ticking leaves an orphaned interval that then polls
+            // a jobId of null and writes its 404 into a fresh dialog's error.
+            this.stopPolling();
             this.jobId = null;
             this.status = null;
             this.completed = 0;

--- a/app/tasmota/api.py
+++ b/app/tasmota/api.py
@@ -1,6 +1,8 @@
 """API endpoints for the Tasmota updater web application"""
 
+import ipaddress
 import os
+import socket
 from pathlib import Path
 from typing import Any
 from flask import request, jsonify, current_app
@@ -15,6 +17,7 @@ from app.tasmota.updater import (
 )
 from app.tasmota.utils import load_devices_from_file, resolve_dns_name, is_fake_device
 from app.tasmota import device_config
+from app.tasmota import discovery
 from app.tasmota import jobs
 
 
@@ -626,7 +629,181 @@ class JobResource(Resource):
         job = jobs.get_job(job_id)
         if job is None:
             return {'error': 'Job not found'}, 404
+
+        if job.get('kind') == 'discovery' and job.get('results'):
+            devices_file = current_app.config.get('DEVICES_FILE', 'devices.yaml')
+            known = {
+                device.get('ip')
+                for device in load_devices_from_file(str(devices_file))
+            }
+            # load_devices_from_file() answers every failure with an empty list.
+            # For a display flag that is harmless — a known device would show up
+            # as new. It must never be a write baseline, and it is not one here:
+            # discovery has no write path at all.
+            job['results'] = [
+                {**entry, 'already_configured': entry.get('ip') in known}
+                for entry in job['results']
+            ]
+
         return job
+
+
+# A /22 is 1024 addresses — about 25 seconds at 64 workers. Wide enough for any
+# home network, narrow enough that the endpoint cannot be turned into a sweep.
+MAX_SCAN_PREFIX = 22
+MAX_SCAN_HOSTS = 1024
+
+
+def validate_scan_target(value: str) -> ipaddress.IPv4Network:
+    """Decide whether a network may be scanned at all.
+
+    Deliberately stricter than ``is_valid_ip_address()``, which allows public
+    addresses because a device may legitimately sit on one. A *scan* is a
+    different matter: an endpoint that sweeps arbitrary public ranges is a port
+    scanner behind someone's session cookie. Private IPv4 only, and bounded.
+    """
+    try:
+        network = ipaddress.ip_network(value.strip(), strict=False)
+    except (ValueError, AttributeError) as exc:
+        raise ValidationError(f"Not a usable network: {value!r}") from exc
+
+    if not isinstance(network, ipaddress.IPv4Network):
+        raise ValidationError("Only IPv4 networks can be scanned.")
+    if network.is_loopback or network.is_link_local or network.is_multicast:
+        raise ValidationError("Loopback, link-local and multicast ranges cannot be scanned.")
+    if not network.is_private:
+        raise ValidationError(
+            "Only private networks can be scanned, so the scanner cannot be "
+            "pointed at the public internet."
+        )
+    if network.prefixlen < MAX_SCAN_PREFIX:
+        raise ValidationError(
+            f"Network is too large: /{network.prefixlen} exceeds the "
+            f"/{MAX_SCAN_PREFIX} limit of {MAX_SCAN_HOSTS} addresses."
+        )
+    return network
+
+
+def suggest_local_networks() -> list[str]:
+    """Guess the local network, to prefill the scan field.
+
+    A UDP socket 'connected' to an arbitrary address reveals which interface
+    would carry the traffic, without sending a packet. It reveals the address,
+    not its prefix length — /24 is an assumption, which is exactly why the API
+    calls this a suggestion and the UI keeps the field editable.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect(("192.0.2.1", 9))  # TEST-NET-1, guaranteed unrouted
+        local_ip = probe.getsockname()[0]
+    except OSError:
+        return []
+    finally:
+        probe.close()
+
+    try:
+        network = ipaddress.ip_network(f"{local_ip}/24", strict=False)
+    except ValueError:
+        return []
+    return [str(network)] if network.is_private else []
+
+
+def _validation_message(exc: ValidationError) -> str:
+    """Flatten a ValidationError into one readable sentence for the client."""
+    messages = exc.messages
+    if isinstance(messages, list):
+        return "; ".join(str(message) for message in messages)
+    return str(messages)
+
+
+class DiscoveryResource(Resource):
+    """Find Tasmota devices on the network. Never writes anything.
+
+    Findings are suggestions: they leave through the job endpoint and the user
+    adopts them in the editor, which saves through PUT /api/config/devices.
+    Keeping the write path out of here is what leaves device_config with a
+    single caller.
+    """
+
+    def get(self):
+        """
+        Get scan suggestions and limits
+        ---
+        tags:
+          - discovery
+        responses:
+          200:
+            description: A suggested network to scan and the enforced limits
+            examples:
+              application/json:
+                suggested_networks: ["192.168.1.0/24"]
+                limits: {max_prefix: 22, max_hosts: 1024}
+        """
+        return {
+            "suggested_networks": suggest_local_networks(),
+            "limits": {"max_prefix": MAX_SCAN_PREFIX, "max_hosts": MAX_SCAN_HOSTS},
+        }
+
+    def post(self):
+        """
+        Start a discovery job
+        ---
+        tags:
+          - discovery
+        parameters:
+          - in: body
+            name: body
+            required: true
+            schema:
+              properties:
+                method:
+                  type: string
+                  enum: [mdns, scan]
+                network:
+                  type: string
+                  description: Required for method=scan. Private IPv4, prefix >= 22.
+            examples:
+              scan: {method: scan, network: "192.168.1.0/24"}
+              mdns: {method: mdns}
+        responses:
+          202:
+            description: Job accepted; poll GET /api/jobs/{job_id}
+            examples:
+              application/json: {job_id: "3f2a", status_url: "/api/jobs/3f2a"}
+          400:
+            description: Unknown method, or a network outside the allowed range
+          409:
+            description: A discovery job is already running
+          415:
+            description: Body was not JSON
+        """
+        if not request.is_json:
+            return {'error': 'Unsupported Media Type',
+                    'details': 'Content-Type must be application/json'}, 415
+
+        body = request.get_json(silent=True) or {}
+        method = body.get('method')
+        if method not in ('mdns', 'scan'):
+            return {'error': 'Bad Request',
+                    'details': "'method' must be 'mdns' or 'scan'"}, 400
+
+        hosts = None
+        if method == 'scan':
+            try:
+                network = validate_scan_target(body.get('network') or '')
+            except ValidationError as exc:
+                return {'error': 'Bad Request', 'details': _validation_message(exc)}, 400
+            hosts = discovery.hosts_in_network(network)
+            current_app.logger.info(
+                "Discovery scan requested for %s (%d hosts)", network, len(hosts)
+            )
+        else:
+            current_app.logger.info("Discovery via mDNS requested")
+
+        job_id = jobs.create_discovery_job(method, hosts)
+        if job_id is None:
+            return {'error': 'A discovery job is already in progress'}, 409
+        return {'job_id': job_id, 'status_url': f'/api/jobs/{job_id}'}, 202
 
 
 def init_api(app):
@@ -641,5 +818,6 @@ def init_api(app):
     api.add_resource(DeviceUpdateResource, '/api/update')
     api.add_resource(AllDevicesUpdateResource, '/api/update/all')
     api.add_resource(JobResource, '/api/jobs/<string:job_id>')
+    api.add_resource(DiscoveryResource, '/api/discovery')
 
     return api

--- a/app/tasmota/discovery.py
+++ b/app/tasmota/discovery.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Optional
 
@@ -163,3 +164,106 @@ def hosts_in_network(network: Any) -> list[str]:
     the network itself.
     """
     return [str(host) for host in network.hosts()]
+
+
+# Tasmota announces itself over the generic HTTP service; some builds add a
+# dedicated one. Browsing both costs nothing and catches both.
+MDNS_SERVICES = ("_http._tcp.local.", "_tasmota._tcp.local.")
+
+# How long to listen before answering. mDNS is passive — the only way to find
+# more devices is to wait longer, and four seconds catches a home network.
+MDNS_DURATION = 4.0
+
+
+class MdnsUnavailable(RuntimeError):
+    """zeroconf is not installed or could not be started."""
+
+
+def _import_zeroconf():
+    """Import zeroconf lazily so a missing package fails only the mDNS path.
+
+    Separated into its own function so a test can replace it — the scan path
+    must stay usable even where mDNS cannot work at all.
+    """
+    try:
+        import zeroconf
+        return zeroconf
+    except ImportError:
+        return None
+
+
+def _decode(value: Any) -> Optional[str]:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else None
+
+
+def service_info_to_finding(info: Any) -> Optional[dict[str, Any]]:
+    """Translate one announced service into a finding.
+
+    mDNS carries far less than ``Status 0``: an address, a name, and whatever
+    the device chose to put into its TXT record. The missing fields stay None
+    rather than being guessed — the UI shows what is known.
+    """
+    addresses = info.parsed_addresses() if callable(getattr(info, "parsed_addresses", None)) else []
+    if not addresses:
+        return None
+
+    properties = getattr(info, "properties", None) or {}
+    decoded = {_decode(key): _decode(value) for key, value in properties.items()}
+
+    hostname = (getattr(info, "server", "") or "").rstrip(".")
+    if hostname.endswith(".local"):
+        hostname = hostname[: -len(".local")]
+
+    return {
+        "ip": addresses[0],
+        "hostname": hostname or None,
+        "friendly_name": decoded.get("friendly_name") or decoded.get("devicename"),
+        "module": decoded.get("module"),
+        "firmware_version": decoded.get("version"),
+        "mac": decoded.get("mac"),
+        "requires_auth": False,
+    }
+
+
+def browse_mdns(duration: float = MDNS_DURATION) -> list[dict[str, Any]]:
+    """Collect devices that announce themselves for ``duration`` seconds.
+
+    Passive: this listens, it does not probe anything. In a bridge-network
+    container it will find nothing at all — multicast does not cross the
+    bridge — and that is a fact about the deployment, not an error here. The
+    caller is responsible for saying so.
+    """
+    module = _import_zeroconf()
+    if module is None:
+        raise MdnsUnavailable(
+            "mDNS discovery needs the 'zeroconf' package, which is not installed."
+        )
+
+    found: dict[str, dict[str, Any]] = {}
+
+    def _on_change(zeroconf_instance, service_type, name, state_change, **kwargs):
+        if state_change is not module.ServiceStateChange.Added:
+            return
+        info = zeroconf_instance.get_service_info(service_type, name, timeout=1000)
+        if info is None:
+            return
+        entry = service_info_to_finding(info)
+        if entry:
+            found.setdefault(entry["ip"], entry)
+
+    try:
+        instance = module.Zeroconf()
+    except OSError as exc:
+        # No multicast-capable interface, or the socket could not be bound.
+        raise MdnsUnavailable(f"mDNS could not be started: {exc}") from exc
+
+    try:
+        browser = module.ServiceBrowser(instance, list(MDNS_SERVICES), handlers=[_on_change])
+        time.sleep(duration)
+        browser.cancel()
+    finally:
+        instance.close()
+
+    return list(found.values())

--- a/app/tasmota/discovery.py
+++ b/app/tasmota/discovery.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Optional
 
 import requests
 
@@ -109,3 +110,56 @@ def probe_host(ip: str, *, timeout: float = 1.5, port: int = 80) -> Optional[dic
         return None
 
     return parse_status(payload, ip)
+
+
+# Fixed, and deliberately not reachable from the API. A per-request concurrency
+# knob behind a session is a denial-of-service button.
+DEFAULT_WORKERS = 64
+
+
+def scan_network(
+    hosts: list[str],
+    *,
+    probe: Callable[[str], Optional[dict[str, Any]]] = probe_host,
+    workers: int = DEFAULT_WORKERS,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list[dict[str, Any]]:
+    """Probe every host in ``hosts`` concurrently and return the finds.
+
+    Takes a finished host list, never a CIDR: what may be scanned is a policy
+    question and belongs to the caller. A probe that raises costs its own host
+    and nothing else — in a range of a thousand addresses, one broken host must
+    not abort the sweep.
+    """
+    total = len(hosts)
+    results: list[dict[str, Any]] = []
+    completed = 0
+
+    if not hosts:
+        return results
+
+    with ThreadPoolExecutor(max_workers=min(workers, total)) as pool:
+        futures = {pool.submit(probe, host): host for host in hosts}
+        for future in as_completed(futures):
+            completed += 1
+            try:
+                found = future.result()
+            except Exception as exc:  # one bad host, not a failed scan
+                logger.debug("%s: probe failed: %s", futures[future], exc)
+                found = None
+            if found:
+                results.append(found)
+            if on_progress:
+                on_progress(completed, total)
+
+    return results
+
+
+def hosts_in_network(network: Any) -> list[str]:
+    """Every usable address in an ``ipaddress`` network, as strings.
+
+    ``.hosts()`` already leaves out the network and broadcast address for a
+    normal IPv4 network — the point of going through it rather than iterating
+    the network itself.
+    """
+    return [str(host) for host in network.hosts()]

--- a/app/tasmota/discovery.py
+++ b/app/tasmota/discovery.py
@@ -1,0 +1,111 @@
+"""Find Tasmota devices on the local network.
+
+Pure search logic: probe a host, understand its answer, run a bounded pool of
+probes, browse mDNS. No Flask, no job handling, and deliberately no policy —
+``scan_network()`` takes a finished host list, never a CIDR. Deciding *what may
+be scanned* belongs to the API layer (``api.validate_scan_target()``); keeping
+it out of here is what lets the scanner be tested against a loopback stub,
+which that policy forbids.
+
+Nothing in this module ever sends credentials. A device behind a web password
+is reported as ``requires_auth`` and left alone.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# A Tasmota `Status 0` answer is a few KiB. The cap is not about Tasmota — it
+# stops a hostile host on the LAN from holding a worker on an endless stream.
+MAX_RESPONSE_BYTES = 64 * 1024
+
+# Tasmota's answer when a web password is set. It arrives with HTTP 401.
+AUTH_MARKER = "need user&password"
+
+
+def parse_status(payload: Any, ip: str) -> Optional[dict[str, Any]]:
+    """Turn a ``Status 0`` answer into a finding, or None if it is not Tasmota.
+
+    Strict on purpose: without the ``Status`` block, every JSON-speaking
+    printer and camera on the network would land in the suggestion list.
+    Everything below that block is optional — a minimal firmware answers with
+    far less, and that is still a device worth showing.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("Status"), dict):
+        return None
+
+    status = payload.get("Status") or {}
+    firmware = payload.get("StatusFWR") or {}
+    network = payload.get("StatusNET") or {}
+
+    friendly = status.get("FriendlyName")
+    if isinstance(friendly, list):
+        friendly = friendly[0] if friendly else None
+
+    return {
+        "ip": network.get("IPAddress") or ip,
+        "hostname": network.get("Hostname"),
+        "friendly_name": friendly or status.get("DeviceName"),
+        "module": firmware.get("Hardware"),
+        "firmware_version": firmware.get("Version"),
+        "mac": network.get("Mac"),
+        "requires_auth": False,
+    }
+
+
+def probe_host(ip: str, *, timeout: float = 1.5, port: int = 80) -> Optional[dict[str, Any]]:
+    """Ask one host whether it is a Tasmota device.
+
+    Never sends credentials, never follows a redirect, never retries. ``port``
+    exists so the scanner can be tested against a local stub; production
+    callers leave it at 80.
+    """
+    url = f"http://{ip}:{port}/cm"
+    try:
+        response = requests.get(
+            url,
+            params={"cmnd": "Status 0"},
+            timeout=timeout,
+            allow_redirects=False,
+            stream=True,
+        )
+    except requests.exceptions.RequestException:
+        # The overwhelming majority of addresses in a range answer nothing at
+        # all. That is the normal case, not an error worth logging per host.
+        return None
+
+    try:
+        body = response.raw.read(MAX_RESPONSE_BYTES + 1, decode_content=True) or b""
+    except Exception:  # pragma: no cover - defensive: broken stream mid-read
+        return None
+    finally:
+        response.close()
+
+    if len(body) > MAX_RESPONSE_BYTES:
+        logger.debug("%s: response exceeded %d bytes, ignored", ip, MAX_RESPONSE_BYTES)
+        return None
+
+    text = body.decode("utf-8", errors="replace")
+
+    if response.status_code == 401:
+        if AUTH_MARKER in text.lower():
+            return {
+                "ip": ip, "hostname": None, "friendly_name": None, "module": None,
+                "firmware_version": None, "mac": None, "requires_auth": True,
+            }
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return None
+
+    return parse_status(payload, ip)

--- a/app/tasmota/jobs.py
+++ b/app/tasmota/jobs.py
@@ -40,7 +40,21 @@ def get_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 def batch_in_progress() -> bool:
     with _lock:
-        return any(j["status"] in ("pending", "running") for j in _jobs.values())
+        return _kind_in_progress_locked("batch")
+
+
+def _kind_in_progress_locked(kind: str) -> bool:
+    """Is a job of this kind pending or running? Caller holds the lock.
+
+    Scoped by kind on purpose. Discovery and batch updates share this store,
+    and an unscoped check would let a running scan block every update — and a
+    running update block every scan — silently, and only in production where
+    both are slow enough to overlap.
+    """
+    return any(
+        job["status"] in ("pending", "running") and job.get("kind") == kind
+        for job in _jobs.values()
+    )
 
 
 def _prune_locked() -> None:
@@ -73,11 +87,12 @@ def create_batch_job(
     """
     resolved_updater = updater or update_device_firmware
     with _lock:
-        if any(j["status"] in ("pending", "running") for j in _jobs.values()):
+        if _kind_in_progress_locked("batch"):
             return None
         job_id = uuid.uuid4().hex
         _jobs[job_id] = {
             "job_id": job_id,
+            "kind": "batch",
             "status": "pending",
             "check_only": bool(check_only),
             "total": 0,
@@ -162,6 +177,98 @@ def _run_batch(
             "updated": updated,
         }
         _set(job_id, status="completed", summary=summary, finished_at=clock())
+    except Exception as exc:  # pragma: no cover - defensive; surfaced to the client
+        _set(job_id, status="error", error=str(exc), finished_at=clock())
+
+
+def create_discovery_job(
+    method: str,
+    hosts: Optional[List[str]],
+    *,
+    runner: Optional[Callable[..., List[Dict[str, Any]]]] = None,
+    clock: Callable[[], float] = time.time,
+    background: bool = True,
+) -> Optional[str]:
+    """Create and start a discovery job. Returns its id, or None if one runs.
+
+    ``runner`` receives a single ``on_progress(completed, total)`` callback and
+    returns the findings; it is injectable so the job mechanics can be tested
+    without touching the network.
+    """
+    resolved = runner or _default_discovery_runner(method, hosts)
+    with _lock:
+        if _kind_in_progress_locked("discovery"):
+            return None
+        job_id = uuid.uuid4().hex
+        _jobs[job_id] = {
+            "job_id": job_id,
+            "kind": "discovery",
+            "method": method,
+            "status": "pending",
+            # mDNS has no total: it listens, it does not work through a list.
+            # None says so; a made-up number would drive a lying progress bar.
+            "total": len(hosts) if hosts is not None else None,
+            "completed": 0,
+            "results": [],
+            "notice": None,
+            "error": None,
+            "created_at": clock(),
+            "finished_at": None,
+        }
+        _prune_locked()
+
+    if background:
+        threading.Thread(
+            target=_run_discovery, args=(job_id, resolved, clock), daemon=True
+        ).start()
+    else:
+        _run_discovery(job_id, resolved, clock)
+    return job_id
+
+
+def _default_discovery_runner(method: str, hosts: Optional[List[str]]):
+    """Bind the core function this method needs, without importing at module load."""
+    from app.tasmota import discovery
+
+    if method == "mdns":
+        return lambda on_progress: discovery.browse_mdns()
+    return lambda on_progress: discovery.scan_network(hosts or [], on_progress=on_progress)
+
+
+NO_MDNS_ANSWER = (
+    "No device announced itself. In a bridge-network container mDNS cannot "
+    "work at all, because multicast does not cross the bridge — see the "
+    "container setup documentation."
+)
+
+
+def _run_discovery(
+    job_id: str,
+    runner: Callable[..., List[Dict[str, Any]]],
+    clock: Callable[[], float],
+) -> None:
+    from app.tasmota import discovery
+
+    try:
+        _set(job_id, status="running")
+
+        def on_progress(completed: int, total: int) -> None:
+            _set(job_id, completed=completed, total=total)
+
+        results = runner(on_progress)
+
+        with _lock:
+            job = _jobs.get(job_id)
+            method = job.get("method") if job else None
+
+        # "Nothing found" and "nothing could reach us" are different answers.
+        # Only the mDNS path can hit the second one, so only it gets the notice.
+        notice = NO_MDNS_ANSWER if not results and method == "mdns" else None
+
+        _set(job_id, status="completed", results=list(results), notice=notice,
+             finished_at=clock())
+    except discovery.MdnsUnavailable as exc:
+        _set(job_id, status="error", error=str(exc), finished_at=clock())
     except Exception as exc:  # pragma: no cover - defensive; surfaced to the client
         _set(job_id, status="error", error=str(exc), finished_at=clock())
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -193,7 +193,8 @@
             </div>
         </section>
 
-        <section class="section" x-data="devicesEditor()" x-init="init()">
+        <section class="section" x-data="devicesEditor()" x-init="init()"
+                 @discovery-adopt.window="adoptDiscovered($event.detail.devices)">
           <h2 class="title is-4">Manage Devices</h2>
 
           <div class="notification is-warning" x-show="!writable" x-cloak>
@@ -268,6 +269,12 @@
           <div class="buttons">
             <button class="button" type="button" :disabled="!writable || !loaded" @click="addDevice()"
                     title="Add a new device to the list">Add Device</button>
+            <button class="button is-info" type="button" data-testid="open-discovery"
+                    :disabled="!writable || !loaded"
+                    @click="$dispatch('discovery-open')"
+                    title="Find Tasmota devices on your network and add them to this list">
+              Find Devices
+            </button>
             <button class="button is-primary" type="button"
                     :disabled="!writable || !loaded || saving" :class="{'is-loading': saving}"
                     @click="save()"
@@ -318,7 +325,113 @@
         </div>
     </div>
 
+    <!-- Discovery: finds devices, never writes. Picks leave as a
+         `discovery-adopt` event and become unsaved rows in the editor. -->
+    <div x-data="discoveryModal()" @discovery-open.window="open()"
+         class="modal" :class="{ 'is-active': isOpen }" data-testid="discovery-modal">
+      <div class="modal-background" @click="close()"></div>
+      <div class="modal-card">
+        <header class="modal-card-head">
+          <p class="modal-card-title">Find Devices</p>
+          <button class="delete" type="button" aria-label="Close this dialog"
+                  title="Close this dialog and stop watching the search"
+                  @click="close()"></button>
+        </header>
+        <section class="modal-card-body">
+
+          <div class="field">
+            <div class="control">
+              <button class="button" type="button" data-testid="start-mdns"
+                      :disabled="isRunning" @click="start('mdns')"
+                      title="Listen for devices that announce themselves via mDNS — passive, sends nothing">
+                Search via mDNS
+              </button>
+            </div>
+            <p class="help">
+              Passive and harmless, but it only works when the app shares the
+              network with the devices. In a bridge-network container it cannot
+              find anything.
+            </p>
+          </div>
+
+          <div class="field has-addons">
+            <div class="control is-expanded">
+              <input class="input" type="text" x-model="network"
+                     data-testid="scan-network"
+                     :placeholder="`e.g. 192.168.1.0/24 (max /${limits.max_prefix})`"
+                     aria-label="Network to scan in CIDR notation">
+            </div>
+            <div class="control">
+              <button class="button is-warning" type="button" data-testid="start-scan"
+                      :disabled="isRunning" @click="start('scan')"
+                      title="Scan this network — sends one HTTP request to every address in the range">
+                Scan Network
+              </button>
+            </div>
+          </div>
+
+          <div x-show="isRunning" x-cloak aria-live="polite" data-testid="discovery-progress">
+            <p x-text="progressLabel"></p>
+            <progress class="progress is-small is-info"
+                      :value="total ? completed : null" :max="total || 100"></progress>
+          </div>
+
+          <div class="notification is-warning" x-show="notice" x-cloak
+               data-testid="discovery-notice" aria-live="polite" x-text="notice"></div>
+          <div class="notification is-danger" x-show="error" x-cloak
+               data-testid="discovery-error" aria-live="assertive" x-text="error"></div>
+
+          <table class="table is-fullwidth" x-show="results.length" x-cloak
+                 data-testid="discovery-results">
+            <thead>
+              <tr>
+                <th scope="col"><span class="is-sr-only">Select</span></th>
+                <th scope="col">Address</th><th scope="col">Name</th>
+                <th scope="col">Firmware</th><th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="device in results" :key="device.ip">
+                <tr>
+                  <td>
+                    <input type="checkbox" :value="device.ip"
+                           :disabled="device.already_configured"
+                           :aria-label="`Select ${device.ip} to add to the device list`"
+                           @change="toggle(device.ip)">
+                  </td>
+                  <td x-text="device.ip"></td>
+                  <td x-text="device.friendly_name || device.hostname || '—'"></td>
+                  <td x-text="device.firmware_version || '—'"></td>
+                  <td>
+                    <span class="tag is-light" x-show="device.already_configured">Already in list</span>
+                    <span class="tag is-warning" x-show="device.requires_auth"
+                          title="This device is password-protected — add its credentials after adding it to the list">
+                      Credentials needed
+                    </span>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+
+          <p x-show="status === 'completed' && !results.length && !notice" x-cloak
+             data-testid="discovery-empty">No Tasmota devices answered in this range.</p>
+
+        </section>
+        <footer class="modal-card-foot">
+          <button class="button is-primary" type="button" data-testid="adopt-selected"
+                  :disabled="!selected.length" @click="adopt()"
+                  title="Add the selected devices to the list — nothing is written until you press Save">
+            Add Selected to List
+          </button>
+          <button class="button" type="button" @click="close()"
+                  title="Close this dialog and stop watching the search">Close</button>
+        </footer>
+      </div>
+    </div>
+
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/devices-editor.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/discovery.js') }}"></script>
 </body>
 </html>

--- a/docs/api.md
+++ b/docs/api.md
@@ -186,6 +186,112 @@ Initiates firmware updates for all configured devices.
 }
 ```
 
+### Device Discovery
+
+Discovery finds Tasmota devices on the network. It **never writes** the
+configuration: the result is a list of suggestions, and adopting them into
+`devices.yaml` goes through the regular editor endpoint.
+
+Both searches run as background jobs, because a full range scan takes about
+25 seconds and would otherwise block the single worker.
+
+#### Get Scan Suggestions and Limits
+
+```
+GET /api/discovery
+```
+
+**Response Example:**
+
+```json
+{
+  "suggested_networks": ["192.168.1.0/24"],
+  "limits": {"max_prefix": 22, "max_hosts": 1024}
+}
+```
+
+`suggested_networks` is a *guess*: the app can determine which interface would
+carry the traffic, but not that interface's prefix length, so `/24` is assumed.
+Treat it as a prefill, not as a fact — correct it if your network is larger.
+
+#### Start a Discovery Job
+
+```
+POST /api/discovery
+```
+
+**Request Body:**
+
+```json
+{"method": "scan", "network": "192.168.1.0/24"}
+```
+
+or
+
+```json
+{"method": "mdns"}
+```
+
+**Response Example (202 Accepted):**
+
+```json
+{"job_id": "3f2a9c1e...", "status_url": "/api/jobs/3f2a9c1e..."}
+```
+
+The scan target is validated server-side and cannot be widened by the client:
+private IPv4 only, prefix `>= 22`, no loopback, link-local or multicast. A host
+address with a prefix (`192.168.1.55/24`) is normalised to its network. A
+rejected target returns `400` with the reason in `details`.
+
+**Status codes:** `202` accepted · `400` unknown method or disallowed network ·
+`409` a discovery job is already running · `415` body was not JSON.
+
+#### Poll a Discovery Job
+
+```
+GET /api/jobs/{job_id}
+```
+
+**Response Example:**
+
+```json
+{
+  "job_id": "3f2a9c1e...",
+  "kind": "discovery",
+  "method": "scan",
+  "status": "completed",
+  "completed": 254,
+  "total": 254,
+  "results": [
+    {
+      "ip": "192.168.1.42",
+      "hostname": "tasmota-1234",
+      "friendly_name": "Hallway Light",
+      "module": "ESP8266EX",
+      "firmware_version": "14.2.0(release-tasmota)",
+      "mac": "AA:BB:CC:DD:EE:FF",
+      "requires_auth": false,
+      "already_configured": false
+    }
+  ],
+  "notice": null,
+  "error": null
+}
+```
+
+Notes on the fields:
+
+- `total` is `null` for `mdns`: that search listens rather than working through
+  a list, so there is no total to report and none is invented.
+- `requires_auth` marks a device that answered with HTTP 401. Discovery never
+  sends credentials — not even ones already stored — so this is a result, not a
+  reason for a second attempt. Add the credentials in the editor after adopting
+  the device.
+- `already_configured` marks an address that is already in `devices.yaml`.
+- `notice` carries an explanation when an empty result would otherwise mislead.
+  An mDNS run that finds nothing in a bridge-network container says so, rather
+  than implying that no devices exist.
+
 ## Error Handling
 
 The API uses standard HTTP status codes to indicate the success or failure of requests:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,24 +1,24 @@
 # API Documentation
 
-The Tasmota Remote Updater provides a comprehensive REST API that allows you to integrate its functionality into your own applications or automation systems.
-
-> **Note:** This API follows [Semantic Versioning 2.0.0](https://semver.org/). Breaking changes will only be introduced in new major versions.
+The Tasmota Remote Updater provides a REST API that allows you to integrate its functionality into your own applications or automation systems.
 
 ## API Overview
 
-The API is built using Flask-RESTful and is documented using Swagger/OpenAPI. You can access the interactive API documentation at http://localhost:5001/apidocs/ when the web application is running.
+The API is built using Flask-RESTful and is documented using Swagger/OpenAPI. You can access the interactive API documentation at http://localhost:5001/apidocs/ when the web application is running. That page is generated from the code and is therefore the authoritative reference if it ever disagrees with this document.
 
 ## Base URL
 
 All API endpoints are relative to the base URL of your Tasmota Remote Updater installation:
 
 ```
-http://localhost:5001/api/v1
+http://localhost:5001
 ```
+
+There is **no `/api/v1` prefix.** Endpoints live directly under `/api/`, and the application version is not part of the URL — query `/version` for it.
 
 ## Version Information
 
-You can retrieve the current version of the API using the version endpoint:
+You can retrieve the current version of the application using the version endpoint. It needs no authentication:
 
 ```
 GET /version
@@ -28,14 +28,42 @@ Example response:
 
 ```json
 {
-  "version": "0.1.0",
-  "name": "Tasmota Updater"
+  "name": "Tasmota Updater",
+  "version": "0.5.4"
 }
+```
+
+## Health Check
+
+For container orchestration. Needs no authentication:
+
+```
+GET /health
+```
+
+```json
+{"status": "healthy"}
 ```
 
 ## Authentication
 
-Currently, the API does not require authentication. If you're exposing the API to untrusted networks, consider implementing appropriate network-level security measures.
+**Every `/api/*` endpoint requires authentication.** The gate is fail-closed: a request that presents neither credential is rejected with `401`, no exceptions.
+
+There are two ways in:
+
+1. **Session cookie (the bundled web UI).** Loading `GET /` sets a signed, HttpOnly, `SameSite=Strict` session cookie. The UI's own requests carry it automatically. Because the cookie is `SameSite=Strict`, a cross-site request cannot send it, which is what makes the API CSRF-safe.
+2. **`X-API-Key` header (programmatic clients).** Set the `API_KEY` environment variable to a strong value, then send it as `X-API-Key`. If `API_KEY` is unset, this route is disabled entirely and only the UI session works.
+
+```bash
+curl -H "X-API-Key: your-key-here" http://localhost:5001/api/devices
+```
+
+Two further rules apply to every state-changing request:
+
+- **The body must be JSON.** A `POST` or `PUT` without `Content-Type: application/json` is rejected with `415`.
+- **CORS defaults to same-origin.** Set `CORS_ORIGINS` to allow cross-origin clients.
+
+> **Note:** `SESSION_COOKIE_SECURE` defaults to `false` so the UI works over plain HTTP on a LAN. Set it to `true` when you serve the app behind HTTPS.
 
 ## Endpoints
 
@@ -44,10 +72,10 @@ Currently, the API does not require authentication. If you're exposing the API t
 #### List All Devices
 
 ```
-GET /api/v1/devices
+GET /api/devices
 ```
 
-Returns a list of all configured devices.
+Returns all configured devices — the *operational* view, enriched for display.
 
 **Response Example:**
 
@@ -56,19 +84,20 @@ Returns a list of all configured devices.
   "devices": [
     {
       "ip": "192.168.1.100",
-      "username": "admin"
-    },
-    {
-      "ip": "192.168.1.101"
+      "username": "admin",
+      "password": "********",
+      "dns_name": "hallway.local"
     }
   ]
 }
 ```
 
+> **Do not write this response back as configuration.** The password is masked to `********`, and `dns_name` is the *resolved* name, falling back to the IP itself when nothing resolves. Round-tripping it would destroy stored passwords and write `dns_name: 192.168.1.100` into every device that has no name. Use `/api/config/devices` for editing.
+
 #### Get Device Status
 
 ```
-GET /api/v1/devices/{device_ip}/status
+GET /api/devices/{device_ip}
 ```
 
 Returns the status of a specific device, including its current firmware version.
@@ -78,19 +107,77 @@ Returns the status of a specific device, including its current firmware version.
 ```json
 {
   "ip": "192.168.1.100",
-  "version": "9.5.0",
+  "version": "12.0.2",
   "core_version": "2.7.4.9",
-  "sdk_version": "2.2.2-dev",
+  "sdk_version": "3.0.2",
   "is_minimal": false
 }
 ```
+
+### Device Configuration
+
+The editing counterpart to `/api/devices`: raw configured fields, no enrichment. This is what the web UI's device editor uses, and it is the only path that writes `devices.yaml`.
+
+#### Read the Configuration
+
+```
+GET /api/config/devices
+```
+
+**Response Example:**
+
+```json
+{
+  "devices": [
+    {
+      "ip": "192.168.1.100",
+      "username": "admin",
+      "has_password": true,
+      "dns_name": "hallway",
+      "timeout": 240
+    }
+  ],
+  "writable": true,
+  "devices_file": "/app/config/devices.yaml"
+}
+```
+
+Passwords are never sent back — `has_password` reports only whether one is stored. `writable` is `false` when the file cannot be replaced atomically (see [Container Setup](container-setup.md) on directory mounts).
+
+#### Replace the Configuration
+
+```
+PUT /api/config/devices
+```
+
+**Request Body:**
+
+```json
+{
+  "devices": [
+    {"ip": "192.168.1.100", "username": "admin", "dns_name": "hallway", "timeout": 240}
+  ]
+}
+```
+
+The submitted list decides membership: a device missing from it is deleted. Fields the editor does not manage (`fake`, cached `firmware_info`) are preserved from the existing entry, matched by IP.
+
+Password handling is deliberate:
+
+- **omit `password`** → the stored one is kept
+- **send `password`** → it replaces the stored one
+- **send `remove_password: true`** → the stored one is deleted
+
+Each write is atomic and keeps one backup generation as `devices.yaml.bak`.
+
+**Status codes:** `200` written (returns the stored configuration) · `400` validation failed · `409` the file is not writable or not readable · `415` body was not JSON.
 
 ### Firmware Management
 
 #### Get Latest Release Information
 
 ```
-GET /api/v1/releases/latest
+GET /api/releases/latest
 ```
 
 Returns information about the latest Tasmota firmware release.
@@ -99,22 +186,25 @@ Returns information about the latest Tasmota firmware release.
 
 ```json
 {
-  "version": "12.4.0",
-  "release_date": "2023-09-15",
-  "release_notes": "# Tasmota v12.4.0\n\n- Fixed various bugs\n- Added new features",
-  "download_url": "https://github.com/arendst/Tasmota/releases/download/v12.4.0/tasmota.bin"
+  "version": "15.5.0",
+  "release_date": "2026-06-22",
+  "release_notes": "# RELEASE NOTES\n\n## Migration Information …",
+  "download_url": "https://github.com/arendst/Tasmota/releases/download/v15.5.0/tasmota.bin",
+  "release_url": "https://github.com/arendst/Tasmota/releases/"
 }
 ```
+
+`release_notes` carries the full upstream release notes and is long — expect tens of kilobytes.
 
 ### Update Operations
 
 #### Update Device
 
 ```
-POST /api/v1/updates/device
+POST /api/update
 ```
 
-Initiates a firmware update for a specific device.
+Initiates a firmware update for a specific device. This one is **synchronous** — it returns when the update has been verified or has failed.
 
 **Request Body:**
 
@@ -134,57 +224,82 @@ Initiates a firmware update for a specific device.
   "ip": "192.168.1.100",
   "success": true,
   "message": "Update successful",
-  "current_version": "12.4.0",
-  "latest_version": "12.4.0",
+  "current_version": "15.5.0",
+  "latest_version": "15.5.0",
   "needs_update": false
 }
 ```
 
+> **Set your client timeout above the server's.** A Tasmota device answers `Upgrade 1` with HTTP 200 *immediately* while still running the old firmware, and reboots seconds to minutes later. The server therefore polls until the reported version actually changes before calling the update a success. Its total budget defaults to 240 s — your client must wait longer than that, or you will time out on an update that is still succeeding.
+
 #### Update All Devices
 
 ```
-POST /api/v1/updates/all
+POST /api/update/all
 ```
 
-Initiates firmware updates for all configured devices.
+Starts firmware updates for all configured devices. **Asynchronous:** a batch can take many minutes, which would block the single worker and trip the request timeout, so this returns immediately and you poll for progress.
 
 **Request Body:**
 
 ```json
 {
-  "check_only": false
+  "check_only": false,
+  "update_only_needed": true,
+  "timeout": 240
 }
 ```
+
+**Response Example (202 Accepted):**
+
+```json
+{"job_id": "3f2a9c1e...", "status_url": "/api/jobs/3f2a9c1e..."}
+```
+
+**Status codes:** `202` accepted · `409` a batch update is already running · `415` body was not JSON.
+
+Only one batch update runs at a time. A running *discovery* job does not block it, and vice versa — the two are tracked separately.
+
+#### Poll a Job
+
+```
+GET /api/jobs/{job_id}
+```
+
+Works for both batch updates (`kind: "batch"`) and discovery (`kind: "discovery"`).
 
 **Response Example:**
 
 ```json
 {
+  "job_id": "3f2a9c1e...",
+  "kind": "batch",
+  "status": "running",
+  "total": 4,
+  "completed": 2,
+  "failed": 0,
   "results": [
     {
       "ip": "192.168.1.100",
       "success": true,
       "message": "Update successful",
-      "current_version": "12.4.0",
-      "latest_version": "12.4.0",
-      "needs_update": false
-    },
-    {
-      "ip": "192.168.1.101",
-      "success": false,
-      "message": "Device is not reachable",
-      "current_version": "Unknown",
-      "latest_version": "12.4.0",
-      "needs_update": true
+      "current_version": "15.5.0",
+      "latest_version": "15.5.0",
+      "needs_update": false,
+      "update_started": true,
+      "update_completed": true
     }
   ],
-  "summary": {
-    "total": 2,
-    "success": 1,
-    "needs_update": 1
-  }
+  "summary": null,
+  "error": null
 }
 ```
+
+`status` is one of `pending`, `running`, `completed`, `error`. `results` fills in as devices finish, so you can show progress. `summary` stays `null` until the job completes.
+
+> **`needs_update: false` does not always mean "up to date".** It also means "could not compare" — a failed release lookup reports `latest_version: "Unknown"`. Decide on `latest_version`, not on `success`: a failed *update* still carries a known latest version.
+
+Jobs are kept in memory (at most 50, oldest finished ones pruned) and do not survive a restart.
 
 ### Device Discovery
 
@@ -248,6 +363,8 @@ rejected target returns `400` with the reason in `details`.
 
 #### Poll a Discovery Job
 
+Same endpoint and same mechanics as a batch job — see [Poll a Job](#poll-a-job) above. A discovery job carries `kind: "discovery"` plus `method` and `notice`:
+
 ```
 GET /api/jobs/{job_id}
 ```
@@ -297,48 +414,89 @@ Notes on the fields:
 The API uses standard HTTP status codes to indicate the success or failure of requests:
 
 - **200 OK**: The request was successful
+- **202 Accepted**: A background job was started; poll `status_url` for progress
 - **400 Bad Request**: The request was invalid or cannot be served
+- **401 Unauthorized**: Neither a UI session cookie nor a valid `X-API-Key` was presented
 - **404 Not Found**: The requested resource does not exist
+- **409 Conflict**: A job of that kind is already running, or the configuration file is not writable
+- **415 Unsupported Media Type**: The body was not `Content-Type: application/json`
 - **500 Internal Server Error**: An error occurred on the server
 
-Error responses include a JSON object with an error message:
+Error responses include a JSON object with an error message, and usually a `details` field with the specific reason:
 
 ```json
 {
-  "error": "Device not found"
+  "error": "Bad Request",
+  "details": "Only private networks can be scanned, so the scanner cannot be pointed at the public internet."
 }
 ```
 
 ## Integration Examples
 
+Both examples assume `API_KEY` is set in the application's environment.
+
 ### cURL
 
 ```bash
-# Get all devices
-curl -X GET http://localhost:5001/api/v1/devices
+KEY="your-api-key"
 
-# Update a device
-curl -X POST http://localhost:5001/api/v1/updates/device \
+# Get all devices
+curl -H "X-API-Key: $KEY" http://localhost:5001/api/devices
+
+# Update a single device (synchronous — allow more than the server's 240s budget)
+curl -X POST http://localhost:5001/api/update \
+  -H "X-API-Key: $KEY" \
   -H "Content-Type: application/json" \
-  -d '{"ip": "192.168.1.100"}'
+  -d '{"ip": "192.168.1.100"}' \
+  --max-time 300
+
+# Update all devices (asynchronous)
+JOB=$(curl -s -X POST http://localhost:5001/api/update/all \
+  -H "X-API-Key: $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"update_only_needed": true}' | jq -r .job_id)
+
+curl -H "X-API-Key: $KEY" "http://localhost:5001/api/jobs/$JOB"
 ```
 
 ### Python
 
 ```python
+import time
 import requests
 
-# Get all devices
-response = requests.get("http://localhost:5001/api/v1/devices")
-devices = response.json()["devices"]
+BASE = "http://localhost:5001"
+HEADERS = {"X-API-Key": "your-api-key"}
 
-# Update a device
-response = requests.post(
-    "http://localhost:5001/api/v1/updates/device",
-    json={"ip": "192.168.1.100"}
-)
-result = response.json()
+# Get all devices
+devices = requests.get(f"{BASE}/api/devices", headers=HEADERS).json()["devices"]
+
+# Update a single device. The device answers the flash command immediately and
+# reboots later, so the server keeps polling until the version really changed —
+# the client timeout has to sit above the server's own budget.
+result = requests.post(
+    f"{BASE}/api/update",
+    headers=HEADERS,
+    json={"ip": "192.168.1.100"},
+    timeout=300,
+).json()
+
+# Update all devices, then poll until the job finishes
+job_id = requests.post(
+    f"{BASE}/api/update/all",
+    headers=HEADERS,
+    json={"update_only_needed": True},
+).json()["job_id"]
+
+while True:
+    job = requests.get(f"{BASE}/api/jobs/{job_id}", headers=HEADERS).json()
+    if job["status"] in ("completed", "error"):
+        break
+    print(f"{job['completed']}/{job['total']}")
+    time.sleep(2)
 ```
+
+> For scheduled checks and updates you usually do not need the API at all — the bundled CLI (`python -m app.cli`) drives the same code and reports its outcome through exit codes. See [Command-Line Usage](cli-usage.md).
 
 ## Next Steps
 

--- a/docs/audit-2026-07/2026-08-08-discovery-design.md
+++ b/docs/audit-2026-07/2026-08-08-discovery-design.md
@@ -1,0 +1,264 @@
+# Design: Tasmota-Discovery im Netzwerk
+
+Stand 2026-08-08. Zweiter von zwei Zyklen zu [#99](https://github.com/dodjango/tasmota-auto-updater/issues/99).
+Der erste Zyklus — der Geräte-Editor — ist mit
+[#128](https://github.com/dodjango/tasmota-auto-updater/pull/128) fertig und ist
+die Voraussetzung: Discovery liefert Vorschläge, der Editor nimmt sie auf.
+
+## Ziel und Abgrenzung
+
+Tasmota-Geräte im LAN finden und mit Auswahl in die Geräteliste übernehmen,
+statt IPs von Hand zusammenzusuchen.
+
+Nicht Ziel: automatische Übernahme, dauerhafte Überwachung des Netzes,
+Erkennung verschwundener Geräte, MQTT-basierte Discovery, IPv6,
+Discovery über die CLI.
+
+## Getroffene Entscheidungen
+
+Diese fünf hat der Betreiber entschieden; sie sind die Grundlage von allem
+Weiteren.
+
+| Frage | Entscheidung |
+|---|---|
+| Betriebsmodell? | **Beides muss funktionieren** — Container im Bridge-Netz *und* Host-Betrieb. mDNS kann im Bridge-Netz nichts finden; das wird gesagt, nicht kaschiert. |
+| Methodenwahl? | **Der Nutzer wählt explizit.** Zwei getrennte Aktionen, kein automatischer Fallback vom einen ins andere. |
+| Scan-Bereich? | **UI-Eingabe mit harten Server-Grenzen.** Vorbelegt aus dem erkannten Interface-Netz, serverseitig auf privat und ≥ /22 begrenzt. |
+| Übernahme? | **In den Editor, der Nutzer speichert.** Discovery bekommt keinen Schreibpfad. |
+| Oberflächen? | **API und Web-UI, keine CLI.** Discovery ist interaktiv und hätte keinen sinnvollen Exit-Code-Vertrag. |
+
+Zur dritten Zeile: das erkannte Netz ist ein *Vorschlag*, keine Feststellung.
+Die Ermittlung liefert die eigene Interface-IP, nicht deren Präfixlänge; /24
+ist eine Annahme. Deshalb heißt das Feld `suggested_networks` und die UI zeigt
+es als editierbares Feld.
+
+## Warum ein Job und kein synchroner Request
+
+mDNS braucht rund vier Sekunden Sammelzeit, ein /24 mit 64 parallelen Sockets
+rund acht, ein /22 rund fünfundzwanzig. Ein synchroner Request liefe damit
+gegen den Gunicorn-Timeout — und weil im Betrieb genau *ein* gthread-Worker
+läuft (`gunicorn.conf.py`), würde er nebenbei die ganze Anwendung blockieren.
+
+Discovery läuft deshalb im selben Muster wie die Batch-Updates:
+`POST` → `202 {job_id}` → Polling über `GET /api/jobs/<id>`.
+
+### Der Deadlock, den das mitbringt
+
+`jobs.py` kennt heute nur eine Job-Art. `batch_in_progress()` und die
+Exklusivitätsprüfung in `create_batch_job()` schauen auf **alle** Jobs im
+Store. Ein zweiter Job-Typ im selben Store würde damit ohne weiteres Zutun
+jedes Batch-Update blockieren, solange ein Scan läuft — und umgekehrt.
+
+Der Store bekommt deshalb ein Feld `kind` (`"batch"` | `"discovery"`), und
+beide Prüfungen filtern darauf. Discovery hat eine eigene, unabhängige
+Exklusivität: ein Discovery-Job zur Zeit. Ein Regressionstest hält genau das
+fest.
+
+Store, Lock und `_prune_locked()` bleiben geteilt, `GET /api/jobs/<id>` bleibt
+der eine Polling-Endpunkt. Ein zweiter Job-Store mit kopierter Lock-, Prune-
+und Snapshot-Logik wäre genau die Duplikation, die in diesem Projekt schon
+einmal die CLI gekillt hat.
+
+## Aufbau
+
+Neu ist `app/tasmota/discovery.py` — reine Suchlogik, ohne Flask, ohne
+Job-Verwaltung, testbar wie `updater.py`:
+
+| Funktion | Aufgabe |
+|---|---|
+| `browse_mdns(duration)` | browst `_http._tcp.local.` und `_tasmota._tcp.local.` |
+| `scan_network(hosts, *, probe, workers, on_progress)` | Thread-Pool über eine **fertige** Host-Liste |
+| `probe_host(ip, timeout)` | `GET http://<ip>/cm?cmnd=Status%200`, ohne Credentials |
+| `parse_status(payload)` | IP, Hostname, Friendly Name, Modul, Firmware-Version, MAC |
+
+Im Kern steckt bewusst **keine** Policy. `scan_network()` bekommt Hosts, keinen
+CIDR. Die Prüfung „was darf überhaupt gescannt werden" sitzt als
+`validate_scan_target()` in der API-Schicht.
+
+Das ist keine Kosmetik: die Policy verbietet Loopback, und ein Kernpfad-Test
+muss gegen einen lokalen Stub-Server auf Loopback laufen können. Läge die
+Prüfung im Scanner, wäre der einzige ehrliche Test des Scanners unmöglich —
+und übrig bliebe ein Test, der `probe_host` mockt und damit nichts beweist.
+
+## Identifikation
+
+Ein Host gilt genau dann als Tasmota, wenn
+
+- HTTP 200 mit JSON, das einen `Status`-Block enthält, oder
+- HTTP 401 mit `Need user&password` im Körper.
+
+Alles andere wird verworfen. Ohne diese Strenge landen Drucker, Kameras und
+jeder andere HTTP-Sprecher im Netz in der Vorschlagsliste.
+
+Der zweite Fall wird als `requires_auth: true` ausgewiesen — als *Ergebnis*,
+nicht als Anlass für einen zweiten Versuch. Siehe Sicherheitsregel 1.
+
+## API
+
+### `GET /api/discovery`
+
+Was die UI zum Vorbelegen braucht:
+
+```json
+{
+  "suggested_networks": ["192.168.1.0/24"],
+  "limits": {"max_prefix": 22, "max_hosts": 1024}
+}
+```
+
+Die Ermittlung braucht keine neue Dependency: ein UDP-`connect()` auf eine
+Dummy-Adresse verrät die eigene Interface-IP, ohne ein Paket zu senden.
+
+### `POST /api/discovery`
+
+```json
+{"method": "mdns"}
+{"method": "scan", "network": "192.168.1.0/24"}
+```
+
+→ `202 {"job_id": "…"}`.
+`400` bei abgelehntem Netz, mit der Begründung im Klartext.
+`409`, wenn bereits ein Discovery-Job läuft.
+
+### `GET /api/jobs/<id>`
+
+Liefert für Discovery-Jobs zusätzlich `kind`, `method`, `notice` und pro Fund:
+
+```json
+{"ip": "192.168.1.42", "hostname": "tasmota-42", "friendly_name": "Flur",
+ "module": "Sonoff Basic", "firmware_version": "14.2.0",
+ "mac": "AA:BB:CC:DD:EE:FF", "requires_auth": false,
+ "already_configured": false}
+```
+
+`completed`/`total` tragen den Fortschritt. Bei mDNS bleibt `total` `null` —
+die Zahl ist dort nicht bekannt, und eine erfundene wäre gelogen.
+
+`already_configured` markiert IPs, die schon in der Konfiguration stehen.
+
+## Sicherheit
+
+Discovery stellt einen Netzwerk-Scanner hinter die API. Das Zugangs-Gate ist
+seit v0.5.0 fail-closed ([#69](https://github.com/dodjango/tasmota-auto-updater/issues/69))
+und erbt sich automatisch: Session-Cookie oder `X-API-Key`, und der `POST`
+verlangt JSON. Darüber hinaus gelten fünf Regeln, die nicht verhandelbar sind.
+
+1. **Nie Credentials beim Probing** — auch nicht die aus `devices.yaml`. Ein
+   Scanner, der gespeicherte Passwörter gegen unbekannte Hosts wirft, ist
+   Credential-Spraying. `requires_auth` ist deshalb ein Ergebnis und löst
+   keinen zweiten Versuch aus.
+2. **`validate_scan_target()`**: nur IPv4, muss `is_private` sein, kein
+   Loopback, Link-Local, Multicast oder Unspecified, Präfix ≥ /22. Netz- und
+   Broadcast-Adresse werden übersprungen. Ein Scan ins öffentliche Netz ist
+   damit strukturell unmöglich, nicht bloß unüblich.
+3. **Parallelität (64) und Host-Timeout (1,5 s) sind fest verdrahtet** und über
+   die API nicht steuerbar. Ein per Request einstellbarer Parallelitätsgrad
+   wäre ein DoS-Knopf hinter der Session.
+4. **Kein Retry, `allow_redirects=False`, Response-Körper auf 64 KiB
+   begrenzt.** Ein bösartiger Host im LAN darf keinen Worker mit einem endlosen
+   Stream festhalten und den Scanner nicht auf ein anderes Ziel umlenken.
+5. **Kein Scan läuft automatisch** — auch nicht beim Öffnen des Dialogs. Jeder
+   Scan ist ein bewusster Klick auf einen Knopf, der vorher sagt, was er tut.
+
+Logging läuft wie überall über `sanitize_log_data()`. Die Fundliste kann keine
+Credentials enthalten, weil nie welche gesendet werden.
+
+Für das Threat-Model ([#74](https://github.com/dodjango/tasmota-auto-updater/issues/74))
+fällt hier ein fertiger Abschnitt ab: neue Angriffsfläche „Netzwerk-Scanner
+hinter der API" mit den Gegenmaßnahmen 1–5.
+
+## Neue Dependency
+
+`zeroconf`, ausschließlich für mDNS. Vor der Aufnahme läuft der
+`dependency-guard`-Check (OSV, Alter, Adoption, Typosquat), wie es die
+Projektregel für jedes neue Paket verlangt.
+
+Ist der Import nicht möglich, endet ein mDNS-Job als `error` mit klarer
+Meldung — der Scan-Pfad bleibt davon unberührt.
+
+## Frontend
+
+Ein Knopf im Geräte-Editor öffnet ein Modal mit zwei getrennten Aktionen:
+„Search via mDNS" (ein Klick, keine Parameter) und „Scan network" (CIDR-Feld,
+vorbelegt). Die Oberfläche bleibt Englisch (`<html lang="en">`).
+
+Beide Knöpfe tragen laut Projektkonvention einen Tooltip mit Aktionsverb; der
+Scan-Tooltip warnt ausdrücklich, dass eine HTTP-Anfrage an jede Adresse im
+angegebenen Netz geht.
+
+Fortschritt: beim Scan ein Balken aus `completed`/`total`, bei mDNS ein Spinner
+mit Restzeit. Kein erfundener Balken, wo kein `total` existiert.
+
+Funde erscheinen mit Auswahlkästchen. Bereits konfigurierte Geräte sind
+sichtbar, aber deaktiviert und als solche beschriftet; `requires_auth`-Funde
+bekommen ein Hinweis-Abzeichen. Die Auswahl fügt ungespeicherte Zeilen in den
+Editor ein — gespeichert wird nur über dessen bestehenden Speichern-Knopf und
+damit über `PUT /api/config/devices`.
+
+Das Modal zu schließen beendet **nicht** den Serverjob, sondern nur die
+Anzeige. Der Knopf heißt deshalb „Close", nicht „Cancel". Ein echtes Abbrechen
+wäre zusätzlicher Zustand für höchstens 25 gesparte Sekunden.
+
+Barrierefreiheit: Fokusfalle im Modal, `aria-live` für den Fortschritt,
+`data-testid`-Haken für Playwright.
+
+## Fehlerverhalten
+
+| Lage | Verhalten |
+|---|---|
+| Einzelner Host antwortet nicht | Normalfall, kein Job-Fehler, kein Log-Eintrag pro Host |
+| mDNS ohne Treffer | `completed`, leere Liste, `notice`: kein Gerät hat sich angekündigt; im Bridge-Netz-Container kann mDNS grundsätzlich nichts finden |
+| Scan ohne Treffer | `completed`, leere Liste, klarer Text |
+| `zeroconf` nicht importierbar | `error` mit Klartext-Meldung |
+| Netz abgelehnt | `400` mit Begründung, kein Job |
+| Discovery-Job läuft schon | `409` |
+
+Der mDNS-Fall ist der wichtigste: „keine Geräte gefunden" wäre dort schlicht
+falsch — gefunden wurde nichts, *weil nichts ankommen konnte*. Das gehört zur
+selben Ehrlichkeitslinie wie `isVersionComparisonKnown()`
+([#91](https://github.com/dodjango/tasmota-auto-updater/issues/91)).
+
+## Tests
+
+- **Unit** `discovery.py`: `parse_status()` gegen echte Fixtures — Tasmota
+  `Status 0`, 401-Körper, fremdes JSON-Gerät, kaputtes JSON.
+  `validate_scan_target()` als Tabelle über privat/öffentlich/zu groß/Müll.
+- **Echter Kernpfad, ungemockt:** `scan_network()` gegen einen lokalen
+  HTTP-Stub auf Loopback mit drei Ports — Tasmota, 401, Fremdgerät. `probe_host`
+  wird dabei *nicht* gemockt. Genau dieses Mocking hat beim `--force`-Feature
+  verborgen, dass der Kern nicht kann, was die Oberfläche versprach
+  ([#126](https://github.com/dodjango/tasmota-auto-updater/issues/126)).
+- **`jobs.py`:** Regressionstest, dass ein Discovery-Job keinen Batch-Job
+  blockiert und umgekehrt.
+- **API:** 202/400/409, Zugangs-Gate nach dem Muster aus `test_auth_gate.py`,
+  `already_configured`-Markierung.
+- **E2E:** Modal, Job per `page.route` gestubbt, Übernahme in den Editor.
+  Ein Schreibtest läuft auf einer Kopie von `devices-dev.yaml`, nie auf dem
+  Original. Vor dem PR läuft die ganze e2e-Suite — neue Markierung bricht
+  bestehende Tests über Playwrights Strict Mode.
+
+## Doku
+
+- `docs/container-setup.md`: zweite Compose-Variante mit `network_mode: host`
+  für mDNS, samt ehrlicher Aufstellung, was man dafür aufgibt (Netz-Isolation,
+  Port-Mapping).
+- `docs/api.md` und Swagger-Docstrings mit Request- und Response-Beispielen.
+- `docs/web-interface.md`: der Discovery-Ablauf.
+- `docs/configuration.md`: die Grenzen. Es gibt **keine** neue
+  Pflicht-Umgebungsvariable.
+- `docs/contributing.md`: „Device Discovery" fällt aus den *Areas for
+  Improvement*.
+- README-Prüfung und `mkdocs build --strict` vor dem PR.
+
+## Restrisiken
+
+- **Der /24-Vorschlag kann falsch sein.** Wer ein /23 fährt, sieht die Hälfte
+  seiner Geräte nicht und muss den CIDR korrigieren. Bewusst in Kauf genommen:
+  die Präfixlänge ohne neue Dependency zu ermitteln, ist plattformabhängig.
+- **mDNS im Bridge-Netz findet nichts.** Kein Fehler, sondern Physik. Die
+  Gegenmaßnahme ist Text, nicht Code.
+- **Ein Scan erzeugt Last im LAN.** 1024 HTTP-Anfragen sind für ein
+  Heimnetz unkritisch, aber nicht null. Deshalb opt-in und nie automatisch.
+- **`already_configured` nutzt den Lesepfad** (`load_devices_from_file()`), der
+  jeden Fehler mit einer leeren Liste beantwortet. Im schlimmsten Fall gilt ein
+  bekanntes Gerät als neu — reine Anzeige, kein Schreibpfad, harmlos.

--- a/docs/audit-2026-07/2026-08-08-discovery-plan.md
+++ b/docs/audit-2026-07/2026-08-08-discovery-plan.md
@@ -1,0 +1,1738 @@
+# Network Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Find Tasmota devices on the LAN — by mDNS or by a fenced IP range scan — and let the user adopt the findings into the device editor.
+
+**Architecture:** A new core module `app/tasmota/discovery.py` holds pure search logic with no Flask and no job handling, mirroring `updater.py`. The existing in-memory job store gains a `kind` field so a discovery job and a batch update no longer block each other. The API layer owns the scan policy; the core owns the mechanics. Discovery has no write path at all — findings become unsaved rows in the editor and the user saves them through the existing `PUT /api/config/devices`.
+
+**Tech Stack:** Python 3.10+, Flask-RESTful, Marshmallow, `requests`, `zeroconf`, Alpine.js v3, Bulma, pytest, pytest-playwright.
+
+Design spec: `docs/audit-2026-07/2026-08-08-discovery-design.md`.
+
+## Global Constraints
+
+- **Dependency floor: `zeroconf>=0.149.12`.** Anything older carries GHSA-9663-mqmp-p9mm / CVE-2026-48045, a LAN-local memory exhaustion through flooded TC-bit mDNS queries — precisely this feature's threat model. The floor is not cosmetic.
+- **Never send credentials while probing.** Not from `devices.yaml`, not from anywhere. `requires_auth` is a result, never a reason for a second attempt.
+- **Scan concurrency is fixed at 64, host timeout at 1.5 s, no retries.** Neither is reachable from the API — a per-request concurrency knob is a DoS button behind the session.
+- **`allow_redirects=False` and a 64 KiB response cap on every probe.**
+- **Scan policy lives in the API layer** (`validate_scan_target()`), never inside `discovery.py`. The core scanner must stay testable against a loopback stub, and the policy forbids loopback.
+- **The web UI is English** (`<html lang="en">`), including every new string. Log messages and code comments follow the surrounding code.
+- **Every interactive element gets a tooltip starting with an action verb**; the scan button's tooltip states outright that it sends an HTTP request to every address in the range.
+- **Prefer `data-testid` over class selectors** in new markup — a second `.notification.is-danger` has already broken the e2e suite through Playwright strict mode.
+- Test command for the green core: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`. Running a single file needs `-o addopts=""` or the coverage flags fail the partial run.
+- `create_app()` takes **no** arguments — construct it, then `config.update({...})`. An authenticated test client needs `session["ui_authenticated"] = True`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `app/tasmota/discovery.py` (create) | Pure search: probe, parse, scan pool, mDNS browse. No Flask, no jobs, no policy. |
+| `app/tasmota/jobs.py` (modify) | Gains `kind`, kind-scoped exclusivity, `create_discovery_job()`. |
+| `app/tasmota/api.py` (modify) | `validate_scan_target()`, `DiscoveryResource`, route registration, Swagger docs. |
+| `app/static/js/discovery.js` (create) | Alpine component: modal state, polling, selection. |
+| `app/static/js/devices-editor.js` (modify) | Accepts adopted findings as unsaved rows. |
+| `app/templates/index.html` (modify) | Discovery button and modal markup. |
+| `tests/test_discovery.py` (create) | Unit tests for parse/validate + the ungmocked loopback scan. |
+| `tests/test_discovery_api.py` (create) | Endpoint contract: 202/400/409/401. |
+| `tests/test_jobs.py` (modify) | Regression: discovery and batch jobs do not block each other. |
+| `tests/e2e/test_discovery.py` (create) | Modal, stubbed job, adoption into the editor. |
+| `requirements.txt` (modify) | `zeroconf>=0.149.12`. |
+| `docs/*` (modify) | container-setup, api, web-interface, configuration, contributing. |
+
+---
+
+### Task 1: Core probe and parse
+
+**Files:**
+- Create: `app/tasmota/discovery.py`
+- Test: `tests/test_discovery.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `parse_status(payload: dict, ip: str) -> dict | None`, `probe_host(ip: str, *, timeout: float = 1.5, port: int = 80) -> dict | None`. The returned dict has keys `ip`, `hostname`, `friendly_name`, `module`, `firmware_version`, `mac`, `requires_auth`.
+
+Note the `port` keyword on `probe_host` — it exists so Task 2's ungmocked test can point the real scanner at a loopback stub on an ephemeral port. Production callers never pass it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Unit tests for the discovery core."""
+import pytest
+
+from app.tasmota import discovery
+
+TASMOTA_STATUS = {
+    "Status": {"Module": 1, "DeviceName": "Hallway", "FriendlyName": ["Hallway Light"]},
+    "StatusFWR": {"Version": "14.2.0(release-tasmota)", "Hardware": "ESP8266EX"},
+    "StatusNET": {"Hostname": "tasmota-1234", "IPAddress": "192.168.1.42",
+                  "Mac": "AA:BB:CC:DD:EE:FF"},
+}
+
+
+def test_parse_status_extracts_the_fields_the_ui_shows():
+    result = discovery.parse_status(TASMOTA_STATUS, "192.168.1.42")
+    assert result == {
+        "ip": "192.168.1.42",
+        "hostname": "tasmota-1234",
+        "friendly_name": "Hallway Light",
+        "module": "ESP8266EX",
+        "firmware_version": "14.2.0(release-tasmota)",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "requires_auth": False,
+    }
+
+
+def test_parse_status_survives_a_sparse_payload():
+    """A minimal device still answers Status 0 — it must not crash the scan."""
+    result = discovery.parse_status({"Status": {}}, "192.168.1.7")
+    assert result is not None
+    assert result["ip"] == "192.168.1.7"
+    assert result["firmware_version"] is None
+    assert result["friendly_name"] is None
+
+
+def test_parse_status_rejects_a_foreign_json_device():
+    """A printer answering JSON is not a Tasmota. No Status block, no entry."""
+    assert discovery.parse_status({"printer": {"model": "X"}}, "192.168.1.9") is None
+
+
+def test_parse_status_rejects_a_non_mapping():
+    assert discovery.parse_status([1, 2, 3], "192.168.1.9") is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.tasmota.discovery'`
+
+- [ ] **Step 3: Write the module**
+
+```python
+"""Find Tasmota devices on the local network.
+
+Pure search logic: probe a host, understand its answer, run a bounded pool of
+probes, browse mDNS. No Flask, no job handling, and deliberately no policy —
+``scan_network()`` takes a finished host list, never a CIDR. Deciding *what may
+be scanned* belongs to the API layer (``api.validate_scan_target()``); keeping
+it out of here is what lets the scanner be tested against a loopback stub,
+which that policy forbids.
+
+Nothing in this module ever sends credentials. A device behind a web password
+is reported as ``requires_auth`` and left alone.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# A Tasmota `Status 0` answer is a few KiB. The cap is not about Tasmota — it
+# stops a hostile host on the LAN from holding a worker on an endless stream.
+MAX_RESPONSE_BYTES = 64 * 1024
+
+# Tasmota's answer when a web password is set. It arrives with HTTP 401.
+AUTH_MARKER = "need user&password"
+
+
+def parse_status(payload: Any, ip: str) -> Optional[dict[str, Any]]:
+    """Turn a ``Status 0`` answer into a finding, or None if it is not Tasmota.
+
+    Strict on purpose: without the ``Status`` block, every JSON-speaking
+    printer and camera on the network would land in the suggestion list.
+    Everything below that block is optional — a minimal firmware answers with
+    far less, and that is still a device worth showing.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("Status"), dict):
+        return None
+
+    status = payload.get("Status") or {}
+    firmware = payload.get("StatusFWR") or {}
+    network = payload.get("StatusNET") or {}
+
+    friendly = status.get("FriendlyName")
+    if isinstance(friendly, list):
+        friendly = friendly[0] if friendly else None
+
+    return {
+        "ip": network.get("IPAddress") or ip,
+        "hostname": network.get("Hostname"),
+        "friendly_name": friendly or status.get("DeviceName"),
+        "module": firmware.get("Hardware"),
+        "firmware_version": firmware.get("Version"),
+        "mac": network.get("Mac"),
+        "requires_auth": False,
+    }
+
+
+def probe_host(ip: str, *, timeout: float = 1.5, port: int = 80) -> Optional[dict[str, Any]]:
+    """Ask one host whether it is a Tasmota device.
+
+    Never sends credentials, never follows a redirect, never retries. ``port``
+    exists so the scanner can be tested against a local stub; production
+    callers leave it at 80.
+    """
+    url = f"http://{ip}:{port}/cm"
+    try:
+        response = requests.get(
+            url,
+            params={"cmnd": "Status 0"},
+            timeout=timeout,
+            allow_redirects=False,
+            stream=True,
+        )
+    except requests.exceptions.RequestException:
+        # The overwhelming majority of addresses in a range answer nothing at
+        # all. That is the normal case, not an error worth logging per host.
+        return None
+
+    try:
+        body = response.raw.read(MAX_RESPONSE_BYTES + 1, decode_content=True) or b""
+    except Exception:  # pragma: no cover - defensive: broken stream mid-read
+        return None
+    finally:
+        response.close()
+
+    if len(body) > MAX_RESPONSE_BYTES:
+        logger.debug("%s: response exceeded %d bytes, ignored", ip, MAX_RESPONSE_BYTES)
+        return None
+
+    text = body.decode("utf-8", errors="replace")
+
+    if response.status_code == 401:
+        if AUTH_MARKER in text.lower():
+            return {
+                "ip": ip, "hostname": None, "friendly_name": None, "module": None,
+                "firmware_version": None, "mac": None, "requires_auth": True,
+            }
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        payload = requests.models.complexjson.loads(text)
+    except ValueError:
+        return None
+
+    return parse_status(payload, ip)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/discovery.py tests/test_discovery.py
+git commit -F- <<'MSG'
+feat(discovery): probe a host and understand its Status 0 answer
+
+Strict identification on purpose: without a `Status` block the answer is
+discarded, so JSON-speaking printers and cameras stay out of the suggestion
+list. A 401 carrying Tasmota's `Need user&password` marker counts as a find
+and is reported as requires_auth — as a result, never as a reason to try
+again with credentials.
+
+The response body is capped at 64 KiB and redirects are not followed, so a
+hostile host on the LAN can neither hold a worker on an endless stream nor
+steer the probe somewhere else.
+MSG
+```
+
+---
+
+### Task 2: The scan pool, tested against a real server
+
+**Files:**
+- Modify: `app/tasmota/discovery.py`
+- Test: `tests/test_discovery.py`
+
+**Interfaces:**
+- Consumes: `probe_host()` from Task 1.
+- Produces: `scan_network(hosts: list[str], *, probe=probe_host, workers: int = 64, on_progress=None) -> list[dict]`. `on_progress` is called as `on_progress(completed: int, total: int)` after each host.
+
+This task carries the plan's most important test. Every `--force` test in [#126](https://github.com/dodjango/tasmota-auto-updater/issues/126) mocked the runner and thereby hid that the core could not do what the surface promised. A scan test that mocks `probe_host` proves only that a thread pool calls a function. So one test drives the real `probe_host` against three real HTTP servers on loopback.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Answers like the device its `mode` says. Set by the factory below."""
+
+    mode = "tasmota"
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler's interface
+        if self.mode == "tasmota":
+            body = json.dumps(TASMOTA_STATUS).encode()
+            self.send_response(200)
+        elif self.mode == "auth":
+            body = json.dumps({"WARNING": "Need user&password"}).encode()
+            self.send_response(401)
+        else:
+            body = json.dumps({"printer": {"model": "X"}}).encode()
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # keep the test output readable
+        pass
+
+
+def _start_stub(mode):
+    handler = type("Handler", (_StubHandler,), {"mode": mode})
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+@pytest.fixture
+def stub_servers():
+    servers = {mode: _start_stub(mode) for mode in ("tasmota", "auth", "foreign")}
+    yield {mode: s.server_address[1] for mode, s in servers.items()}
+    for server in servers.values():
+        server.shutdown()
+
+
+def test_scan_finds_real_devices_without_mocking_the_probe(stub_servers):
+    """The one test that drives the real probe over a real socket.
+
+    Mocking probe_host here would only prove that a thread pool calls a
+    function — exactly the blind spot that let #126 ship.
+    """
+    found = []
+    for mode, port in stub_servers.items():
+        results = discovery.scan_network(
+            ["127.0.0.1"],
+            probe=lambda ip, port=port: discovery.probe_host(ip, port=port, timeout=2.0),
+        )
+        found.extend(results)
+
+    by_auth = {entry["requires_auth"]: entry for entry in found}
+    assert len(found) == 2, "the foreign JSON device must not be reported"
+    assert by_auth[False]["firmware_version"] == "14.2.0(release-tasmota)"
+    assert by_auth[True]["ip"] == "127.0.0.1"
+
+
+def test_scan_reports_progress_for_every_host():
+    seen = []
+    discovery.scan_network(
+        [f"192.0.2.{n}" for n in range(1, 6)],
+        probe=lambda ip: None,
+        on_progress=lambda completed, total: seen.append((completed, total)),
+    )
+    assert [c for c, _ in seen] == [1, 2, 3, 4, 5]
+    assert {t for _, t in seen} == {5}
+
+
+def test_scan_survives_a_probe_that_raises():
+    """One broken host must not abort the whole range."""
+    def flaky(ip):
+        if ip.endswith(".2"):
+            raise RuntimeError("boom")
+        return {"ip": ip, "requires_auth": False}
+
+    results = discovery.scan_network(["192.0.2.1", "192.0.2.2", "192.0.2.3"], probe=flaky)
+    assert sorted(r["ip"] for r in results) == ["192.0.2.1", "192.0.2.3"]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v`
+Expected: FAIL — `AttributeError: module 'app.tasmota.discovery' has no attribute 'scan_network'`
+
+- [ ] **Step 3: Implement the pool**
+
+Append to `app/tasmota/discovery.py`:
+
+```python
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Iterable
+
+# Fixed, and deliberately not reachable from the API. A per-request concurrency
+# knob behind a session is a denial-of-service button.
+DEFAULT_WORKERS = 64
+
+
+def scan_network(
+    hosts: list[str],
+    *,
+    probe: Callable[[str], Optional[dict[str, Any]]] = probe_host,
+    workers: int = DEFAULT_WORKERS,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+) -> list[dict[str, Any]]:
+    """Probe every host in ``hosts`` concurrently and return the finds.
+
+    Takes a finished host list, never a CIDR: what may be scanned is a policy
+    question and belongs to the caller. A probe that raises costs its own host
+    and nothing else — in a range of a thousand addresses, one broken host must
+    not abort the sweep.
+    """
+    total = len(hosts)
+    results: list[dict[str, Any]] = []
+    completed = 0
+
+    if not hosts:
+        return results
+
+    with ThreadPoolExecutor(max_workers=min(workers, total)) as pool:
+        futures = {pool.submit(probe, host): host for host in hosts}
+        for future in as_completed(futures):
+            completed += 1
+            try:
+                found = future.result()
+            except Exception as exc:  # one bad host, not a failed scan
+                logger.debug("%s: probe failed: %s", futures[future], exc)
+                found = None
+            if found:
+                results.append(found)
+            if on_progress:
+                on_progress(completed, total)
+
+    return results
+
+
+def hosts_in_network(network: Any) -> list[str]:
+    """Every usable address in an ``ipaddress`` network, as strings.
+
+    ``.hosts()`` already leaves out the network and broadcast address for a
+    normal IPv4 network — the point of going through it rather than iterating
+    the network itself.
+    """
+    return [str(host) for host in network.hosts()]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/tasmota/discovery.py tests/test_discovery.py
+git commit -F- <<'MSG'
+feat(discovery): scan a host list with a bounded worker pool
+
+Concurrency is fixed at 64 and cannot be reached from the API — a
+per-request concurrency knob behind a session would be a DoS button. A probe
+that raises costs its own host and nothing else; across a thousand addresses
+one broken host must not abort the sweep.
+
+The pool takes a finished host list rather than a CIDR. What may be scanned
+is policy and stays in the API layer, which is also what makes the test
+below possible: it drives the real probe over a real socket against three
+loopback stubs (Tasmota, 401, foreign JSON), and the policy forbids
+loopback. A test that mocked probe_host would only prove that a thread pool
+calls a function — the blind spot that let #126 ship.
+MSG
+```
+
+---
+
+### Task 3: mDNS browse and the dependency
+
+**Files:**
+- Modify: `app/tasmota/discovery.py`, `requirements.txt`
+- Test: `tests/test_discovery.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `browse_mdns(duration: float = 4.0) -> list[dict]`, `MdnsUnavailable` exception.
+
+- [ ] **Step 1: Add the dependency**
+
+Append to `requirements.txt` after `watchdog>=6.0.0`:
+
+```
+zeroconf>=0.149.12
+```
+
+The floor is mandatory, not stylistic: everything below 0.149.12 carries GHSA-9663-mqmp-p9mm (CVE-2026-48045), an unbounded TC-deferred queue that lets any host on the local link exhaust memory through spoofed mDNS floods.
+
+Run: `uv pip install -r requirements.txt`
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+def test_browse_mdns_raises_when_zeroconf_is_missing(monkeypatch):
+    monkeypatch.setattr(discovery, "_import_zeroconf", lambda: None)
+    with pytest.raises(discovery.MdnsUnavailable):
+        discovery.browse_mdns(duration=0.01)
+
+
+def test_service_info_becomes_a_finding():
+    """The browse callback's translation step, tested without a network."""
+    class FakeInfo:
+        parsed_addresses = staticmethod(lambda: ["192.168.1.42"])
+        server = "tasmota-1234.local."
+        properties = {b"friendly_name": b"Hallway Light", b"module": b"Sonoff Basic"}
+
+    entry = discovery.service_info_to_finding(FakeInfo())
+    assert entry["ip"] == "192.168.1.42"
+    assert entry["hostname"] == "tasmota-1234"
+    assert entry["friendly_name"] == "Hallway Light"
+    assert entry["requires_auth"] is False
+
+
+def test_service_info_without_an_address_is_skipped():
+    class FakeInfo:
+        parsed_addresses = staticmethod(lambda: [])
+        server = "ghost.local."
+        properties = {}
+
+    assert discovery.service_info_to_finding(FakeInfo()) is None
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v -k mdns or service_info`
+Expected: FAIL — `AttributeError: ... has no attribute 'MdnsUnavailable'`
+
+- [ ] **Step 4: Implement the browse**
+
+Append to `app/tasmota/discovery.py`:
+
+```python
+import time
+
+# Tasmota announces itself over the generic HTTP service; some builds add a
+# dedicated one. Browsing both costs nothing and catches both.
+MDNS_SERVICES = ("_http._tcp.local.", "_tasmota._tcp.local.")
+
+
+class MdnsUnavailable(RuntimeError):
+    """zeroconf is not installed or could not be started."""
+
+
+def _import_zeroconf():
+    """Import zeroconf lazily so a missing package fails only the mDNS path.
+
+    Separated into its own function so a test can replace it — the scan path
+    must stay usable even where mDNS cannot work at all.
+    """
+    try:
+        import zeroconf  # noqa: PLC0415 - deliberate lazy import
+        return zeroconf
+    except ImportError:
+        return None
+
+
+def _decode(value: Any) -> Optional[str]:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else None
+
+
+def service_info_to_finding(info: Any) -> Optional[dict[str, Any]]:
+    """Translate one announced service into a finding.
+
+    mDNS carries far less than ``Status 0``: an address, a name, and whatever
+    the device chose to put into its TXT record. The missing fields stay None
+    rather than being guessed — the UI shows what is known.
+    """
+    addresses = info.parsed_addresses() if callable(getattr(info, "parsed_addresses", None)) else []
+    if not addresses:
+        return None
+
+    properties = getattr(info, "properties", None) or {}
+    decoded = {_decode(key): _decode(value) for key, value in properties.items()}
+
+    hostname = (getattr(info, "server", "") or "").rstrip(".")
+    if hostname.endswith(".local"):
+        hostname = hostname[: -len(".local")]
+
+    return {
+        "ip": addresses[0],
+        "hostname": hostname or None,
+        "friendly_name": decoded.get("friendly_name") or decoded.get("devicename"),
+        "module": decoded.get("module"),
+        "firmware_version": decoded.get("version"),
+        "mac": decoded.get("mac"),
+        "requires_auth": False,
+    }
+
+
+def browse_mdns(duration: float = 4.0) -> list[dict[str, Any]]:
+    """Collect devices that announce themselves for ``duration`` seconds.
+
+    Passive: this listens, it does not probe anything. In a bridge-network
+    container it will find nothing at all — multicast does not cross the
+    bridge — and that is a fact about the deployment, not an error here. The
+    caller is responsible for saying so.
+    """
+    module = _import_zeroconf()
+    if module is None:
+        raise MdnsUnavailable(
+            "mDNS discovery needs the 'zeroconf' package, which is not installed."
+        )
+
+    found: dict[str, dict[str, Any]] = {}
+
+    def _on_change(zc, service_type, name, state_change, **kwargs):
+        if state_change is not module.ServiceStateChange.Added:
+            return
+        info = zc.get_service_info(service_type, name, timeout=1000)
+        if info is None:
+            return
+        entry = service_info_to_finding(info)
+        if entry:
+            found.setdefault(entry["ip"], entry)
+
+    zc = module.Zeroconf()
+    try:
+        browser = module.ServiceBrowser(zc, list(MDNS_SERVICES), handlers=[_on_change])
+        time.sleep(duration)
+        browser.cancel()
+    finally:
+        zc.close()
+
+    return list(found.values())
+```
+
+- [ ] **Step 5: Run the whole discovery test file**
+
+Run: `pytest tests/test_discovery.py -o addopts="" -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/tasmota/discovery.py tests/test_discovery.py requirements.txt
+git commit -F- <<'MSG'
+feat(discovery): browse mDNS for devices that announce themselves
+
+Browses both `_http._tcp` and `_tasmota._tcp`; Tasmota uses the generic
+service and some builds add the dedicated one. mDNS carries far less than a
+Status 0 answer, so the unknown fields stay null instead of being guessed.
+
+zeroconf is imported lazily behind its own function, so a missing package
+fails the mDNS path alone and leaves the scan path — the one that works
+everywhere — untouched.
+
+Dependency vetting for zeroconf: OSV clean at 0.150.0, first released
+2014-07-08, 262 versions, maintained by the python-zeroconf org, no
+typosquat lookalikes. The `>=0.149.12` floor is required rather than
+cosmetic: earlier versions carry GHSA-9663-mqmp-p9mm (CVE-2026-48045), an
+unbounded TC-deferred queue that lets any host on the local link exhaust
+memory through spoofed mDNS floods — this feature's own threat model.
+MSG
+```
+
+---
+
+### Task 4: A second job kind, without the deadlock
+
+**Files:**
+- Modify: `app/tasmota/jobs.py`
+- Test: `tests/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `discovery.browse_mdns()`, `discovery.scan_network()`, `discovery.MdnsUnavailable` from Tasks 2–3.
+- Produces: `create_discovery_job(method: str, hosts: list[str] | None, *, runner=None, clock=time.time, background=True) -> str | None`. Returns None when a discovery job is already running. Every job dict now carries `kind`.
+
+The trap this task exists to avoid: `batch_in_progress()` and the exclusivity check inside `create_batch_job()` currently scan **all** jobs in the store. Adding a second kind without scoping them means a running scan silently blocks every batch update, and vice versa.
+
+- [ ] **Step 1: Write the failing regression test**
+
+Append to `tests/test_jobs.py`:
+
+```python
+def test_a_running_discovery_job_does_not_block_a_batch_update():
+    """The deadlock this design had to sidestep.
+
+    Both kinds share one store. If the batch exclusivity check keeps looking
+    at every job in it, a scan blocks every update for as long as it runs —
+    silently, and only in production where scans are slow.
+    """
+    jobs._reset_for_tests()
+
+    def slow_scan(on_progress):
+        time.sleep(0.2)
+        return []
+
+    discovery_id = jobs.create_discovery_job("scan", ["192.0.2.1"], runner=slow_scan)
+    assert discovery_id is not None
+
+    batch_id = jobs.create_batch_job(
+        [{"ip": "192.0.2.9"}], check_only=True, update_only_needed=False,
+        global_timeout=None, updater=lambda cfg, check_only=False: {"success": True},
+        background=False,
+    )
+    assert batch_id is not None, "a running scan must not block a batch update"
+    assert jobs.get_job(batch_id)["kind"] == "batch"
+    assert jobs.get_job(discovery_id)["kind"] == "discovery"
+
+
+def test_only_one_discovery_job_runs_at_a_time():
+    jobs._reset_for_tests()
+
+    def slow_scan(on_progress):
+        time.sleep(0.2)
+        return []
+
+    assert jobs.create_discovery_job("scan", ["192.0.2.1"], runner=slow_scan) is not None
+    assert jobs.create_discovery_job("scan", ["192.0.2.2"], runner=slow_scan) is None
+
+
+def test_discovery_job_records_results_and_progress():
+    jobs._reset_for_tests()
+    finding = {"ip": "192.0.2.5", "requires_auth": False}
+
+    def runner(on_progress):
+        on_progress(1, 1)
+        return [finding]
+
+    job_id = jobs.create_discovery_job("scan", ["192.0.2.5"], runner=runner, background=False)
+    job = jobs.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["results"] == [finding]
+    assert job["completed"] == 1 and job["total"] == 1
+
+
+def test_mdns_job_without_zeroconf_ends_as_error():
+    jobs._reset_for_tests()
+
+    def runner(on_progress):
+        raise discovery.MdnsUnavailable("no zeroconf here")
+
+    job_id = jobs.create_discovery_job("mdns", None, runner=runner, background=False)
+    job = jobs.get_job(job_id)
+    assert job["status"] == "error"
+    assert "zeroconf" in job["error"]
+```
+
+Add `import time` and `from app.tasmota import discovery` to the file's imports if they are not there yet.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_jobs.py -o addopts="" -v`
+Expected: FAIL — `AttributeError: module 'app.tasmota.jobs' has no attribute 'create_discovery_job'`
+
+- [ ] **Step 3: Scope the existing exclusivity to batch jobs**
+
+In `app/tasmota/jobs.py`, change `batch_in_progress()`:
+
+```python
+def batch_in_progress() -> bool:
+    with _lock:
+        return _kind_in_progress_locked("batch")
+
+
+def _kind_in_progress_locked(kind: str) -> bool:
+    """Is a job of this kind pending or running? Caller holds the lock.
+
+    Scoped by kind on purpose: discovery and batch updates share one store,
+    and an unscoped check would let a running scan block every update.
+    """
+    return any(
+        job["status"] in ("pending", "running") and job.get("kind") == kind
+        for job in _jobs.values()
+    )
+```
+
+In `create_batch_job()`, replace the exclusivity check and add the field:
+
+```python
+    with _lock:
+        if _kind_in_progress_locked("batch"):
+            return None
+        job_id = uuid.uuid4().hex
+        _jobs[job_id] = {
+            "job_id": job_id,
+            "kind": "batch",
+            "status": "pending",
+            ...
+```
+
+(Keep every other key in that dict exactly as it is.)
+
+- [ ] **Step 4: Add the discovery job**
+
+Append to `app/tasmota/jobs.py`:
+
+```python
+def create_discovery_job(
+    method: str,
+    hosts: Optional[List[str]],
+    *,
+    runner: Optional[Callable[..., List[Dict[str, Any]]]] = None,
+    clock: Callable[[], float] = time.time,
+    background: bool = True,
+) -> Optional[str]:
+    """Create and start a discovery job. Returns its id, or None if one runs.
+
+    ``runner`` receives a single ``on_progress(completed, total)`` callback and
+    returns the findings; it is injectable so the job mechanics can be tested
+    without touching the network.
+    """
+    resolved = runner or _default_discovery_runner(method, hosts)
+    with _lock:
+        if _kind_in_progress_locked("discovery"):
+            return None
+        job_id = uuid.uuid4().hex
+        _jobs[job_id] = {
+            "job_id": job_id,
+            "kind": "discovery",
+            "method": method,
+            "status": "pending",
+            "total": len(hosts) if hosts is not None else None,
+            "completed": 0,
+            "results": [],
+            "notice": None,
+            "error": None,
+            "created_at": clock(),
+            "finished_at": None,
+        }
+        _prune_locked()
+
+    if background:
+        threading.Thread(target=_run_discovery, args=(job_id, resolved, clock), daemon=True).start()
+    else:
+        _run_discovery(job_id, resolved, clock)
+    return job_id
+
+
+def _default_discovery_runner(method: str, hosts: Optional[List[str]]):
+    """Bind the core function this method needs, without importing at module load."""
+    from app.tasmota import discovery
+
+    if method == "mdns":
+        return lambda on_progress: discovery.browse_mdns()
+    return lambda on_progress: discovery.scan_network(hosts or [], on_progress=on_progress)
+
+
+NO_MDNS_ANSWER = (
+    "No device announced itself. In a bridge-network container mDNS cannot "
+    "work at all, because multicast does not cross the bridge — see the "
+    "container setup documentation."
+)
+
+
+def _run_discovery(
+    job_id: str,
+    runner: Callable[..., List[Dict[str, Any]]],
+    clock: Callable[[], float],
+) -> None:
+    from app.tasmota import discovery
+
+    try:
+        _set(job_id, status="running")
+
+        def on_progress(completed: int, total: int) -> None:
+            _set(job_id, completed=completed, total=total)
+
+        results = runner(on_progress)
+
+        notice = None
+        with _lock:
+            job = _jobs.get(job_id)
+            method = job.get("method") if job else None
+        if not results and method == "mdns":
+            notice = NO_MDNS_ANSWER
+
+        _set(job_id, status="completed", results=list(results), notice=notice,
+             finished_at=clock())
+    except discovery.MdnsUnavailable as exc:
+        _set(job_id, status="error", error=str(exc), finished_at=clock())
+    except Exception as exc:  # pragma: no cover - defensive; surfaced to the client
+        _set(job_id, status="error", error=str(exc), finished_at=clock())
+```
+
+- [ ] **Step 5: Run the job tests to verify they pass**
+
+Run: `pytest tests/test_jobs.py tests/test_jobs_api.py -o addopts="" -v`
+Expected: PASS, including the four new tests
+
+- [ ] **Step 6: Run the green core to catch fallout**
+
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/tasmota/jobs.py tests/test_jobs.py
+git commit -F- <<'MSG'
+feat(jobs): carry a second job kind without blocking batch updates
+
+Discovery reuses the batch job pattern — 202 with a job id, polled through
+GET /api/jobs/<id> — because a /22 scan takes about 25s and the single
+gthread worker would otherwise be blocked for all of it.
+
+Both kinds share one store, so the exclusivity checks had to become
+kind-scoped. Unscoped they would have let a running scan silently block
+every batch update, and only in production where scans are slow enough to
+notice. A regression test pins both directions.
+
+An mDNS run that finds nothing completes with a notice saying multicast
+cannot cross a container bridge, rather than claiming no devices exist —
+the same honesty line as isVersionComparisonKnown() in #91.
+MSG
+```
+
+---
+
+### Task 5: The endpoints and the scan policy
+
+**Files:**
+- Modify: `app/tasmota/api.py`
+- Test: `tests/test_discovery_api.py` (create)
+
+**Interfaces:**
+- Consumes: `jobs.create_discovery_job()` from Task 4, `discovery.hosts_in_network()` from Task 2.
+- Produces: `validate_scan_target(value: str) -> ipaddress.IPv4Network` (raises `ValidationError`), `suggest_local_networks() -> list[str]`, routes `GET`/`POST /api/discovery`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_discovery_api.py`:
+
+```python
+"""Contract tests for the discovery endpoints."""
+import pytest
+from marshmallow import ValidationError
+
+from app.tasmota import api, jobs
+from server import create_app
+
+MAX_PREFIX = 22
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["ui_authenticated"] = True
+        yield client
+
+
+@pytest.mark.parametrize("value", [
+    "192.168.1.0/24", "10.0.0.0/24", "172.16.5.0/23", "192.168.0.0/22",
+])
+def test_private_networks_within_the_limit_are_accepted(value):
+    assert str(api.validate_scan_target(value)) == value
+
+
+@pytest.mark.parametrize("value,reason", [
+    ("8.8.8.0/24", "public"),
+    ("127.0.0.0/24", "loopback"),
+    ("169.254.0.0/24", "link-local"),
+    ("224.0.0.0/24", "multicast"),
+    ("192.168.0.0/16", "too large"),
+    ("not-a-network", "garbage"),
+    ("fd00::/64", "IPv6"),
+    ("", "empty"),
+])
+def test_targets_outside_the_fence_are_rejected(value, reason):
+    with pytest.raises(ValidationError):
+        api.validate_scan_target(value)
+
+
+def test_get_discovery_offers_a_suggestion_and_the_limits(client):
+    response = client.get("/api/discovery")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["limits"] == {"max_prefix": MAX_PREFIX, "max_hosts": 1024}
+    assert isinstance(body["suggested_networks"], list)
+
+
+def test_post_scan_starts_a_job(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: "job-1")
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "192.168.1.0/24"})
+    assert response.status_code == 202
+    assert response.get_json()["job_id"] == "job-1"
+
+
+def test_post_mdns_starts_a_job(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: "job-2")
+    response = client.post("/api/discovery", json={"method": "mdns"})
+    assert response.status_code == 202
+
+
+def test_post_rejects_a_public_network_with_a_reason(client):
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "8.8.8.0/24"})
+    assert response.status_code == 400
+    assert "private" in response.get_json()["details"].lower()
+
+
+def test_post_reports_a_running_job_as_conflict(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: None)
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "192.168.1.0/24"})
+    assert response.status_code == 409
+
+
+def test_post_requires_json(client):
+    response = client.post("/api/discovery", data="method=scan",
+                           content_type="application/x-www-form-urlencoded")
+    assert response.status_code == 415
+
+
+def test_post_rejects_an_unknown_method(client):
+    response = client.post("/api/discovery", json={"method": "arp-spoof"})
+    assert response.status_code == 400
+
+
+def test_discovery_is_behind_the_auth_gate():
+    """Fail-closed, like every other /api/* route."""
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.test_client() as anonymous:
+        assert anonymous.get("/api/discovery").status_code == 401
+        assert anonymous.post("/api/discovery", json={"method": "mdns"}).status_code == 401
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_discovery_api.py -o addopts="" -v`
+Expected: FAIL — `AttributeError: module 'app.tasmota.api' has no attribute 'validate_scan_target'`
+
+- [ ] **Step 3: Implement the policy and the resource**
+
+Add to the imports at the top of `app/tasmota/api.py`:
+
+```python
+import ipaddress
+import socket
+
+from app.tasmota import discovery
+```
+
+Add before `class DiscoveryResource`:
+
+```python
+# A /22 is 1024 addresses — about 25 seconds at 64 workers. Wide enough for any
+# home network, narrow enough that the endpoint cannot be turned into a sweep.
+MAX_SCAN_PREFIX = 22
+MAX_SCAN_HOSTS = 1024
+
+
+def validate_scan_target(value: str) -> ipaddress.IPv4Network:
+    """Decide whether a network may be scanned at all.
+
+    Deliberately stricter than ``is_valid_ip_address()``, which allows public
+    addresses because a device may legitimately sit on one. A *scan* is a
+    different matter: an endpoint that sweeps arbitrary public ranges is a port
+    scanner behind someone's session cookie. Private IPv4 only, and bounded.
+    """
+    try:
+        network = ipaddress.ip_network(value.strip(), strict=False)
+    except (ValueError, AttributeError) as exc:
+        raise ValidationError(f"Not a usable network: {value!r}") from exc
+
+    if not isinstance(network, ipaddress.IPv4Network):
+        raise ValidationError("Only IPv4 networks can be scanned.")
+    if not network.is_private:
+        raise ValidationError(
+            "Only private networks can be scanned, so the scanner cannot be "
+            "pointed at the public internet."
+        )
+    if network.is_loopback or network.is_link_local or network.is_multicast:
+        raise ValidationError("Loopback, link-local and multicast ranges cannot be scanned.")
+    if network.prefixlen < MAX_SCAN_PREFIX:
+        raise ValidationError(
+            f"Network is too large: /{network.prefixlen} exceeds the /{MAX_SCAN_PREFIX} "
+            f"limit of {MAX_SCAN_HOSTS} addresses."
+        )
+    return network
+
+
+def suggest_local_networks() -> list[str]:
+    """Guess the local network, to prefill the scan field.
+
+    A UDP socket that is 'connected' to an arbitrary address reveals which
+    interface would carry the traffic, without sending a packet. It reveals the
+    address, not its prefix length — /24 is an assumption, which is exactly why
+    the API calls this a suggestion and the UI keeps the field editable.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect(("192.0.2.1", 9))  # TEST-NET-1, guaranteed unrouted
+        local_ip = probe.getsockname()[0]
+    except OSError:
+        return []
+    finally:
+        probe.close()
+
+    try:
+        network = ipaddress.ip_network(f"{local_ip}/24", strict=False)
+    except ValueError:
+        return []
+    return [str(network)] if network.is_private else []
+
+
+class DiscoveryResource(Resource):
+    """Find Tasmota devices on the network. Never writes anything."""
+
+    def get(self):
+        """
+        Get scan suggestions and limits
+        ---
+        tags:
+          - discovery
+        responses:
+          200:
+            description: A suggested network to scan and the enforced limits
+            examples:
+              application/json:
+                suggested_networks: ["192.168.1.0/24"]
+                limits: {max_prefix: 22, max_hosts: 1024}
+        """
+        return {
+            "suggested_networks": suggest_local_networks(),
+            "limits": {"max_prefix": MAX_SCAN_PREFIX, "max_hosts": MAX_SCAN_HOSTS},
+        }
+
+    def post(self):
+        """
+        Start a discovery job
+        ---
+        tags:
+          - discovery
+        parameters:
+          - in: body
+            name: body
+            required: true
+            schema:
+              properties:
+                method:
+                  type: string
+                  enum: [mdns, scan]
+                network:
+                  type: string
+                  description: Required for method=scan. Private IPv4, prefix >= 22.
+            examples:
+              scan: {method: scan, network: "192.168.1.0/24"}
+              mdns: {method: mdns}
+        responses:
+          202:
+            description: Job accepted; poll GET /api/jobs/{job_id}
+            examples:
+              application/json: {job_id: "3f2a…", status_url: "/api/jobs/3f2a…"}
+          400:
+            description: Unknown method, or a network outside the allowed range
+          409:
+            description: A discovery job is already running
+          415:
+            description: Body was not JSON
+        """
+        if not request.is_json:
+            return {'error': 'Unsupported Media Type',
+                    'details': 'Content-Type must be application/json'}, 415
+
+        body = request.get_json(silent=True) or {}
+        method = body.get('method')
+        if method not in ('mdns', 'scan'):
+            return {'error': 'Bad Request',
+                    'details': "'method' must be 'mdns' or 'scan'"}, 400
+
+        hosts = None
+        if method == 'scan':
+            try:
+                network = validate_scan_target(body.get('network') or '')
+            except ValidationError as exc:
+                return {'error': 'Bad Request', 'details': str(exc.messages[0])
+                        if isinstance(exc.messages, list) else str(exc.messages)}, 400
+            hosts = discovery.hosts_in_network(network)
+            current_app.logger.info(
+                "Discovery scan requested for %s (%d hosts)", network, len(hosts)
+            )
+        else:
+            current_app.logger.info("Discovery via mDNS requested")
+
+        job_id = jobs.create_discovery_job(method, hosts)
+        if job_id is None:
+            return {'error': 'A discovery job is already in progress'}, 409
+        return {'job_id': job_id, 'status_url': f'/api/jobs/{job_id}'}, 202
+```
+
+In `init_api()`, register the route next to the others:
+
+```python
+    api.add_resource(DiscoveryResource, '/api/discovery')
+```
+
+- [ ] **Step 4: Mark already-configured findings**
+
+Discovery results must show which devices are already in the configuration. Extend `JobResource.get()` in `app/tasmota/api.py`, right before `return job`:
+
+```python
+        if job.get("kind") == "discovery" and job.get("results"):
+            devices_file = current_app.config.get('DEVICES_FILE', 'devices.yaml')
+            known = {
+                device.get("ip")
+                for device in load_devices_from_file(str(devices_file))
+            }
+            # load_devices_from_file() answers every failure with an empty list.
+            # For a display flag that is harmless — a known device would show up
+            # as new. It must never be used as a write baseline, and is not.
+            job["results"] = [
+                {**entry, "already_configured": entry.get("ip") in known}
+                for entry in job["results"]
+            ]
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pytest tests/test_discovery_api.py -o addopts="" -v`
+Expected: PASS (all cases)
+
+- [ ] **Step 6: Run the green core**
+
+Run: `pytest --ignore=tests/e2e -m "not stale and not slow and not integration and not browser and not docker"`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/tasmota/api.py tests/test_discovery_api.py
+git commit -F- <<'MSG'
+feat(api): expose discovery behind a fenced scan policy
+
+validate_scan_target() is deliberately stricter than is_valid_ip_address():
+that one allows public addresses because a device may legitimately sit on
+one, but a *scan* endpoint that sweeps arbitrary public ranges is a port
+scanner behind someone's session cookie. Private IPv4 only, prefix >= /22,
+no loopback, link-local or multicast.
+
+The scan target is a UI field rather than an env variable, so the fence is
+enforced server-side where it cannot be edited away. GET /api/discovery
+prefills it from the local interface address; the prefix length is not
+knowable that way, so /24 is an assumption and the field is named
+suggested_networks to say so.
+
+Findings are flagged already_configured through the read path, whose
+empty-list-on-failure behaviour is harmless for a display flag and is never
+used as a write baseline. Discovery has no write path at all.
+MSG
+```
+
+---
+
+### Task 6: The discovery modal
+
+**Files:**
+- Create: `app/static/js/discovery.js`
+- Modify: `app/templates/index.html`, `app/static/js/devices-editor.js`
+
+**Interfaces:**
+- Consumes: `GET`/`POST /api/discovery` and `GET /api/jobs/<id>` from Tasks 4–5.
+- Produces: Alpine component `discoveryModal()`; emits a `discovery-adopt` CustomEvent whose `detail.devices` is a list of `{ip, dns_name}` objects for the editor.
+
+- [ ] **Step 1: Write the component**
+
+Create `app/static/js/discovery.js`:
+
+```javascript
+/**
+ * Find Tasmota devices on the network and hand the picks to the editor.
+ *
+ * This component never writes configuration. Adopted devices leave here as a
+ * `discovery-adopt` event and become unsaved rows in the editor, so the single
+ * save path through PUT /api/config/devices stays the only writer.
+ */
+function discoveryModal() {
+    return {
+        isOpen: false,
+        method: null,          // 'mdns' | 'scan' while a job runs
+        network: '',
+        limits: { max_prefix: 22, max_hosts: 1024 },
+        jobId: null,
+        status: null,          // 'pending' | 'running' | 'completed' | 'error'
+        completed: 0,
+        total: null,
+        results: [],
+        selected: [],
+        notice: null,
+        error: null,
+        pollTimer: null,
+
+        async open() {
+            this.isOpen = true;
+            this.reset();
+            try {
+                const response = await fetch('/api/discovery');
+                if (response.ok) {
+                    const body = await response.json();
+                    this.limits = body.limits || this.limits;
+                    this.network = (body.suggested_networks || [])[0] || '';
+                }
+            } catch (err) {
+                // A missing suggestion is not worth an error banner — the user
+                // can type the network. Only a failed *scan* is worth shouting about.
+            }
+        },
+
+        close() {
+            // Stops the polling, not the job. The server finishes on its own
+            // within ~25s; cancelling it would be extra state for nothing.
+            this.isOpen = false;
+            this.stopPolling();
+        },
+
+        reset() {
+            this.jobId = null;
+            this.status = null;
+            this.completed = 0;
+            this.total = null;
+            this.results = [];
+            this.selected = [];
+            this.notice = null;
+            this.error = null;
+        },
+
+        get isRunning() {
+            return this.status === 'pending' || this.status === 'running';
+        },
+
+        get progressLabel() {
+            if (this.method === 'mdns') return 'Listening for announcements…';
+            if (this.total) return `Probed ${this.completed} of ${this.total} addresses`;
+            return 'Starting…';
+        },
+
+        get adoptableResults() {
+            return this.results.filter(device => !device.already_configured);
+        },
+
+        async start(method) {
+            this.reset();
+            this.method = method;
+            const payload = method === 'scan'
+                ? { method, network: this.network }
+                : { method };
+
+            try {
+                const response = await fetch('/api/discovery', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const body = await response.json();
+                if (!response.ok) {
+                    this.error = body.details || body.error || 'Discovery could not be started.';
+                    return;
+                }
+                this.jobId = body.job_id;
+                this.status = 'pending';
+                this.poll();
+            } catch (err) {
+                this.error = 'Discovery could not be started.';
+            }
+        },
+
+        poll() {
+            this.pollTimer = setInterval(async () => {
+                try {
+                    const response = await fetch(`/api/jobs/${this.jobId}`);
+                    if (!response.ok) {
+                        this.error = 'Lost track of the discovery job.';
+                        this.stopPolling();
+                        return;
+                    }
+                    const job = await response.json();
+                    this.status = job.status;
+                    this.completed = job.completed || 0;
+                    this.total = job.total;
+                    this.results = job.results || [];
+                    this.notice = job.notice;
+                    if (job.status === 'completed' || job.status === 'error') {
+                        this.error = job.error;
+                        this.stopPolling();
+                    }
+                } catch (err) {
+                    this.error = 'Lost track of the discovery job.';
+                    this.stopPolling();
+                }
+            }, 1000);
+        },
+
+        stopPolling() {
+            if (this.pollTimer) {
+                clearInterval(this.pollTimer);
+                this.pollTimer = null;
+            }
+        },
+
+        toggle(ip) {
+            const index = this.selected.indexOf(ip);
+            if (index === -1) this.selected.push(ip);
+            else this.selected.splice(index, 1);
+        },
+
+        adopt() {
+            const picks = this.results
+                .filter(device => this.selected.includes(device.ip))
+                .map(device => ({ ip: device.ip, dns_name: device.hostname || '' }));
+            this.$dispatch('discovery-adopt', { devices: picks });
+            this.close();
+        },
+    };
+}
+```
+
+- [ ] **Step 2: Add the markup**
+
+In `app/templates/index.html`, inside the device editor section, add the trigger button:
+
+```html
+<button class="button is-info"
+        data-testid="open-discovery"
+        title="Find Tasmota devices on your network and add them to this list"
+        @click="$refs.discovery.open()">
+    <span>Find devices</span>
+</button>
+```
+
+And the modal, as a sibling of the editor markup:
+
+```html
+<div x-data="discoveryModal()" x-ref="discovery" class="modal"
+     :class="{ 'is-active': isOpen }" data-testid="discovery-modal">
+  <div class="modal-background" @click="close()"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Find devices</p>
+      <button class="delete" aria-label="Close this dialog" @click="close()"></button>
+    </header>
+    <section class="modal-card-body">
+
+      <div class="buttons">
+        <button class="button" data-testid="start-mdns" :disabled="isRunning"
+                title="Listen for devices that announce themselves via mDNS"
+                @click="start('mdns')">Search via mDNS</button>
+      </div>
+
+      <div class="field has-addons">
+        <div class="control is-expanded">
+          <input class="input" type="text" x-model="network"
+                 data-testid="scan-network"
+                 :placeholder="`e.g. 192.168.1.0/24 (max /${limits.max_prefix})`"
+                 aria-label="Network to scan in CIDR notation">
+        </div>
+        <div class="control">
+          <button class="button is-warning" data-testid="start-scan" :disabled="isRunning"
+                  title="Scan this network — sends one HTTP request to every address in the range"
+                  @click="start('scan')">Scan network</button>
+        </div>
+      </div>
+
+      <div x-show="isRunning" aria-live="polite" data-testid="discovery-progress">
+        <p x-text="progressLabel"></p>
+        <progress class="progress is-small is-info"
+                  :value="total ? completed : null" :max="total || 100"></progress>
+      </div>
+
+      <div class="notification is-warning" x-show="notice" data-testid="discovery-notice"
+           aria-live="polite" x-text="notice"></div>
+      <div class="notification is-danger" x-show="error" data-testid="discovery-error"
+           aria-live="assertive" x-text="error"></div>
+
+      <table class="table is-fullwidth" x-show="results.length"
+             data-testid="discovery-results">
+        <thead>
+          <tr><th></th><th>Address</th><th>Name</th><th>Firmware</th><th></th></tr>
+        </thead>
+        <tbody>
+          <template x-for="device in results" :key="device.ip">
+            <tr>
+              <td>
+                <input type="checkbox" :value="device.ip"
+                       :disabled="device.already_configured"
+                       :aria-label="`Select ${device.ip} for adoption`"
+                       @change="toggle(device.ip)">
+              </td>
+              <td x-text="device.ip"></td>
+              <td x-text="device.friendly_name || device.hostname || '—'"></td>
+              <td x-text="device.firmware_version || '—'"></td>
+              <td>
+                <span class="tag is-light" x-show="device.already_configured">Already in list</span>
+                <span class="tag is-warning" x-show="device.requires_auth"
+                      title="This device is password-protected — add credentials after adopting it">
+                  Credentials needed
+                </span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+
+      <p x-show="status === 'completed' && !results.length && !notice"
+         data-testid="discovery-empty">No Tasmota devices answered in this range.</p>
+
+    </section>
+    <footer class="modal-card-foot">
+      <button class="button is-primary" data-testid="adopt-selected"
+              :disabled="!selected.length"
+              title="Add the selected devices to the editor — nothing is saved until you press Save"
+              @click="adopt()">Add selected to list</button>
+      <button class="button" title="Close this dialog and stop watching the search"
+              @click="close()">Close</button>
+    </footer>
+  </div>
+</div>
+```
+
+Register the script next to the existing ones:
+
+```html
+<script src="{{ url_for('static', filename='js/discovery.js') }}"></script>
+```
+
+- [ ] **Step 3: Receive the findings in the editor**
+
+In `app/static/js/devices-editor.js`, add a handler that appends adopted devices as unsaved rows. Add this method to the editor component, matching the naming of the methods already there:
+
+```javascript
+        /**
+         * Take findings from the discovery modal as unsaved rows.
+         *
+         * Deliberately additive and deliberately unsaved: the user still has to
+         * add credentials and press Save, so PUT /api/config/devices remains the
+         * only path that writes the file.
+         */
+        adoptDiscovered(devices) {
+            const known = new Set(this.devices.map(device => device.ip));
+            devices
+                .filter(device => !known.has(device.ip))
+                .forEach(device => {
+                    this.devices.push({
+                        ip: device.ip,
+                        dns_name: device.dns_name || '',
+                        username: '',
+                        password: '',
+                        timeout: null,
+                        has_password: false,
+                    });
+                });
+            this.isDirty = true;
+        },
+```
+
+Wire the event on the editor's root element in `index.html`:
+
+```html
+@discovery-adopt.window="adoptDiscovered($event.detail.devices)"
+```
+
+Check the editor component's existing property names first (`devices`, `isDirty`) and match whatever is actually there — this snippet assumes them.
+
+- [ ] **Step 4: Verify by hand**
+
+Run: `ENV_FILE=.env.dev python server.py`
+Open `http://localhost:5001`, press "Find devices", run a scan against your own network, adopt a device, confirm it appears as an unsaved row and that pressing Save writes it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/static/js/discovery.js app/static/js/devices-editor.js app/templates/index.html
+git commit -F- <<'MSG'
+feat(ui): add the discovery modal and adopt findings into the editor
+
+Two explicit actions rather than one clever button: mDNS is a single click,
+the scan needs a network and says in its tooltip that it sends a request to
+every address in the range. Nothing starts on its own, not even when the
+dialog opens.
+
+The scan shows a real progress bar from completed/total; mDNS shows a
+spinner, because no total exists there and inventing one would be a lie.
+Devices already in the configuration are shown but not selectable, and
+password-protected finds are tagged rather than retried with credentials.
+
+Adoption dispatches an event and appends unsaved rows; the modal never
+writes. Closing it stops the polling, not the job — hence "Close" rather
+than "Cancel".
+MSG
+```
+
+---
+
+### Task 7: End-to-end coverage
+
+**Files:**
+- Create: `tests/e2e/test_discovery.py`
+
+**Interfaces:**
+- Consumes: the markup and `data-testid` hooks from Task 6.
+- Produces: nothing other tasks depend on.
+
+The job is stubbed through `page.route` rather than scanned for real: the e2e run must not depend on what happens to be on the CI runner's network, and a real scan would take 25 seconds per test.
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/e2e/test_discovery.py`:
+
+```python
+"""End-to-end coverage for the discovery modal."""
+import json
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+FINDINGS = [
+    {"ip": "192.168.100.150", "hostname": "tasmota-new", "friendly_name": "Attic",
+     "module": "ESP8266EX", "firmware_version": "14.2.0", "mac": "AA:BB:CC:DD:EE:01",
+     "requires_auth": False, "already_configured": False},
+    {"ip": "192.168.100.101", "hostname": "known", "friendly_name": "Known one",
+     "module": "ESP8266EX", "firmware_version": "13.0.0", "mac": "AA:BB:CC:DD:EE:02",
+     "requires_auth": False, "already_configured": True},
+]
+
+
+def _stub_discovery(page, results, notice=None, status="completed"):
+    page.route("**/api/discovery", lambda route: route.fulfill(
+        status=202, content_type="application/json",
+        body=json.dumps({"job_id": "stub", "status_url": "/api/jobs/stub"}),
+    ) if route.request.method == "POST" else route.fulfill(
+        status=200, content_type="application/json",
+        body=json.dumps({"suggested_networks": ["192.168.100.0/24"],
+                         "limits": {"max_prefix": 22, "max_hosts": 1024}}),
+    ))
+    page.route("**/api/jobs/stub", lambda route: route.fulfill(
+        status=200, content_type="application/json",
+        body=json.dumps({"job_id": "stub", "kind": "discovery", "method": "scan",
+                         "status": status, "completed": 254, "total": 254,
+                         "results": results, "notice": notice, "error": None}),
+    ))
+
+
+def test_scan_lists_findings_and_marks_known_devices(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    page.goto(app_server)
+    page.click('[data-testid="open-discovery"]')
+    page.click('[data-testid="start-scan"]')
+
+    results = page.locator('[data-testid="discovery-results"]')
+    results.wait_for(state="visible")
+    assert results.locator("tbody tr").count() == 2
+
+    known_row = results.locator("tbody tr", has_text="192.168.100.101")
+    assert known_row.locator("input[type=checkbox]").is_disabled()
+
+
+def test_adopting_a_finding_adds_an_unsaved_row(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    page.goto(app_server)
+    page.click('[data-testid="open-discovery"]')
+    page.click('[data-testid="start-scan"]')
+    page.locator('[data-testid="discovery-results"]').wait_for(state="visible")
+
+    page.locator('input[value="192.168.100.150"]').check()
+    page.click('[data-testid="adopt-selected"]')
+
+    # x-show only toggles display, so assert visibility, never count == 0.
+    page.locator('[data-testid="discovery-modal"]').wait_for(state="hidden")
+    assert page.locator('input[value="192.168.100.150"]').count() >= 1
+
+
+def test_an_empty_mdns_run_explains_itself(page, app_server):
+    _stub_discovery(page, [], notice="No device announced itself. In a bridge-network "
+                                     "container mDNS cannot work at all")
+    page.goto(app_server)
+    page.click('[data-testid="open-discovery"]')
+    page.click('[data-testid="start-mdns"]')
+
+    notice = page.locator('[data-testid="discovery-notice"]')
+    notice.wait_for(state="visible")
+    assert "bridge-network" in notice.inner_text()
+```
+
+Check `tests/e2e/conftest.py` for the actual fixture name and signature before running — this assumes an `app_server` fixture that yields the base URL, matching the session-scoped fixture the suite already uses.
+
+- [ ] **Step 2: Run the discovery e2e tests**
+
+Run: `pytest tests/e2e/test_discovery.py -m e2e -o addopts="" -v`
+Expected: PASS
+
+- [ ] **Step 3: Run the whole e2e suite**
+
+Run: `GITHUB_TOKEN=$(gh auth token) pytest tests/e2e -m e2e -o addopts=""`
+Expected: PASS. New markup breaks existing tests through Playwright strict-mode ambiguity, so the full suite is the gate — not just the new file. Without the token the app hits GitHub's 60 req/h limit and the update-flow tests fail with a misleading timeout.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/test_discovery.py
+git commit -m "test(e2e): cover the discovery modal, adoption and the empty-mDNS notice"
+```
+
+---
+
+### Task 8: Documentation
+
+**Files:**
+- Modify: `docs/container-setup.md`, `docs/api.md`, `docs/web-interface.md`, `docs/configuration.md`, `docs/contributing.md`, `README.md`
+
+- [ ] **Step 1: Document the mDNS deployment trade-off**
+
+In `docs/container-setup.md`, add a section explaining that mDNS needs `network_mode: host`, with a second compose variant and an honest list of what that costs (no network isolation, no port mapping, the container shares the host's network stack). State plainly that the IP range scan works in the default bridge setup and that mDNS in a bridge container finds nothing — not because of a bug, but because multicast does not cross the bridge.
+
+- [ ] **Step 2: Document the endpoints**
+
+In `docs/api.md`, add `GET /api/discovery` and `POST /api/discovery` with request and response examples matching the Swagger docstrings from Task 5, plus the polling flow through `GET /api/jobs/<id>` and the `kind: "discovery"` result shape.
+
+- [ ] **Step 3: Document the workflow and the limits**
+
+In `docs/web-interface.md`, describe the modal: two explicit actions, adoption into the editor, and that nothing is saved until Save is pressed.
+
+In `docs/configuration.md`, document the scan limits (private IPv4 only, prefix ≥ /22, 64 concurrent probes, 1.5 s timeout) and state explicitly that discovery introduces **no** new environment variable.
+
+- [ ] **Step 4: Retire the backlog entry**
+
+In `docs/contributing.md`, remove "Device Discovery" from *Areas for Improvement* — it ships here.
+
+- [ ] **Step 5: Check the README**
+
+Run: `grep -c '^```' README.md` (must be even). Verify badges, clone URL, ports, commands, and that no deprecated path is presented as current. Add discovery to the feature list if the README enumerates features. Remember the image is `dodjango/tasmota-updater` while the git repo is `dodjango/tasmota-auto-updater` — do not "correct" either into the other.
+
+- [ ] **Step 6: Verify the docs build**
+
+Run: `mkdocs build --strict`
+Expected: PASS, no broken links.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs README.md
+git commit -F- <<'MSG'
+docs: document discovery, its limits and the mDNS deployment trade-off
+
+The important part is the honest one: the range scan works in the default
+bridge-network container, mDNS does not and cannot, because multicast does
+not cross the bridge. The host-network variant that makes mDNS work is
+written down together with what it costs, rather than being recommended
+outright.
+
+Device Discovery leaves the Areas for Improvement list in contributing.md,
+where it has sat since the beginning.
+MSG
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** every section of the design maps to a task — core module (1–3), the `kind` deadlock (4), API and policy (5), `already_configured` (5, step 4), frontend and honesty rules (6), tests including the ungmocked core path (2, 4, 5, 7), docs (8). The `zeroconf>=0.149.12` floor appears in the global constraints and in Task 3.
+
+**Placeholders:** none — every code step carries the actual code, every test step the actual assertions.
+
+**Type consistency:** the finding dict keys (`ip`, `hostname`, `friendly_name`, `module`, `firmware_version`, `mac`, `requires_auth`) are identical across `parse_status`, `probe_host`, `service_info_to_finding`, the API's `already_configured` enrichment, and the frontend template. `create_discovery_job(method, hosts, *, runner, clock, background)` is called with the same signature in Tasks 4 and 5. `on_progress(completed, total)` matches between `scan_network`, `_run_discovery` and the job fields the frontend polls.
+
+**Known soft spots, flagged rather than hidden:** Task 6 assumes the editor component exposes `devices` and `isDirty`, and Task 7 assumes an `app_server` fixture yielding a base URL. Both steps say to verify the real names first.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,39 @@ A few behaviours are easy to miss:
   (`EBUSY`) and the editor disables itself with an explanation. See
   [Container Setup](container-setup.md) for the directory-mount migration.
 
+## Finding Devices on the Network
+
+Next to "Add Device" the editor has **Find Devices**, which searches the network
+and lets you add what it finds. Two separate searches, chosen explicitly — there
+is no automatic fallback from one to the other, and nothing starts on its own:
+
+- **Search via mDNS** listens for devices that announce themselves. Passive and
+  harmless, but it only works when the app shares the network with the devices.
+  In a bridge-network container it can never find anything, because multicast
+  does not cross the bridge; see [Container Setup](container-setup.md).
+- **Scan network** probes every address in a range you specify. It is prefilled
+  with a guess at your local network — a guess, because the prefix length is not
+  detectable, so `/24` is assumed. Correct it if your network is larger.
+
+Discovery **never writes** the configuration. Selected devices are added to the
+editor as unsaved rows; nothing reaches `devices.yaml` until you press Save.
+
+**Discovery introduces no new environment variable.** The limits below are fixed
+in the application, deliberately: a scanner whose reach can be configured from
+outside is a scanner that ends up pointed somewhere it should not be.
+
+| Limit | Value |
+|---|---|
+| Allowed targets | Private IPv4 only — public, loopback, link-local and multicast are rejected |
+| Largest range | `/22` (1024 addresses) |
+| Parallel probes | 64 |
+| Timeout per address | 1.5 s, no retries |
+| Credentials sent | None, ever |
+
+A password-protected device answers the probe with HTTP 401. It is listed as
+"Credentials needed" and left alone — discovery does not retry it with stored
+passwords. Add its username and password in the editor after adopting it.
+
 ## Environment Variables
 
 The application supports the following environment variables:

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -70,6 +70,72 @@ docker run -d -p 5001:5001 \
 > above; the default `DEVICES_FILE` already expects it there, so only set
 > that variable yourself if you choose a different path.
 
+## Device Discovery and the Network Mode
+
+The web UI can find Tasmota devices for you ("Find Devices" in the *Manage
+Devices* section). It offers two ways to search, and **only one of them works
+in the default container setup**:
+
+| Method | Bridge network (default) | `network_mode: host` |
+|---|---|---|
+| **Scan network** (IP range) | Works | Works |
+| **Search via mDNS** | Finds nothing, ever | Works |
+
+The scan needs nothing special: the container can reach your LAN through the
+bridge, so probing a range of addresses works exactly as it does on the host.
+
+mDNS is different, and the reason is worth stating plainly: mDNS relies on
+multicast traffic, and multicast does not cross a container bridge. This is not
+a bug and no setting inside the application can fix it. In a bridge-network
+container the mDNS search will always come back empty — the UI says so rather
+than claiming that no devices exist.
+
+### Enabling mDNS with host networking
+
+If you want mDNS, the container has to share the host's network stack:
+
+```yaml
+services:
+  tasmota-updater:
+    image: ghcr.io/dodjango/tasmota-updater:latest
+    # Required for mDNS. Read the trade-offs below before enabling this.
+    network_mode: host
+    volumes:
+      - ./config:/app/config
+      - ./logs:/app/logs
+    environment:
+      - DEVICES_FILE=/app/config/devices.yaml
+      - HOST=0.0.0.0
+      - PORT=5001
+    restart: unless-stopped
+```
+
+What you give up by doing this:
+
+- **No network isolation.** The container shares the host's network namespace.
+  It can reach anything the host can reach, and services it opens are host
+  services.
+- **No port mapping.** The `ports:` section stops applying — the app binds
+  `PORT` on the host directly, so that port must be free.
+- **Linux only.** On Docker Desktop for macOS and Windows, `network_mode: host`
+  does not give the container the LAN's multicast traffic, so it does not
+  actually solve the problem there.
+
+**Our recommendation:** keep the default bridge network and use the range scan.
+It finds the same devices, needs no privileges, and costs nothing in isolation.
+Turn on host networking only if you specifically want mDNS and understand the
+trade-off above.
+
+### What the scanner is allowed to do
+
+The scan is fenced server-side and cannot be widened from the browser:
+
+- private IPv4 ranges only — a scan of public address space is rejected
+- at most a `/22` (1024 addresses)
+- 64 probes in parallel, 1.5 s timeout each, no retries
+- no credentials are ever sent; a password-protected device is reported as
+  such and left alone
+
 ## Manual Container Setup
 
 If you prefer to build and run the container manually:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -145,15 +145,14 @@ related issues.
 
 Here are some areas where contributions would be particularly welcome:
 
-1. **Device Discovery**: Implement automatic device discovery on the local network
-2. **Authentication**: Add user authentication for the web interface
-3. **Device Grouping**: Allow organizing devices into logical groups
-4. **Custom Firmware Support**: Add support for custom firmware sources
-5. **Scheduled Updates**: Implement scheduled updates through the web interface
-6. **Notifications**: Add email or push notifications for update results
-7. **Dark Mode**: Implement a dark mode theme for the web interface
-8. **Localization**: Add support for multiple languages
-9. **Push Notifications**: Add support for push notifications
+1. **Authentication**: Add user authentication for the web interface
+2. **Device Grouping**: Allow organizing devices into logical groups
+3. **Custom Firmware Support**: Add support for custom firmware sources
+4. **Scheduled Updates**: Implement scheduled updates through the web interface
+5. **Notifications**: Add email or push notifications for update results
+6. **Dark Mode**: Implement a dark mode theme for the web interface
+7. **Localization**: Add support for multiple languages
+8. **Push Notifications**: Add support for push notifications
 10. **Device Inventory**: Add support for tracking device inventory
 11. **Toggle devices**: Add support for toggling devices on and off
 12. **Bulk actions**: Add support for bulk actions on devices

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,8 +93,32 @@ This guide helps you diagnose and resolve common issues with Tasmota Remote Upda
 
 **Solutions:**
 1. Check the application logs for detailed error information
-2. Verify the API is working using curl: `curl http://localhost:5001/api/v1/devices`
+2. Verify the application is up — this endpoint needs no authentication:
+   `curl http://localhost:5001/health`
 3. Restart the web application
+
+**Getting `401 Unauthorized` on every `/api/*` call?**
+
+That is the intended behaviour, not a fault. The API is fail-closed: it accepts
+either the web UI's session cookie or an `X-API-Key` header, and rejects
+anything else. For a command-line client, set the `API_KEY` environment
+variable on the application and send it:
+
+```bash
+curl -H "X-API-Key: your-key-here" http://localhost:5001/api/devices
+```
+
+If `API_KEY` is unset, the header route is disabled entirely and only the
+browser UI can reach the API. See [API Documentation](api.md) for details.
+
+**Getting `415 Unsupported Media Type` on a POST or PUT?**
+
+State-changing requests must carry `Content-Type: application/json`.
+
+**Getting `404` on an endpoint you found in an older guide?**
+
+There is no `/api/v1` prefix and there never was. The paths are `/api/devices`,
+`/api/update`, `/api/update/all` and so on — see [API Documentation](api.md).
 
 ## Logging and Debugging
 

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -60,6 +60,33 @@ The navigation bar contains buttons for batch operations:
 2. **Check All**: Check for updates on all devices at once
 3. **Update All**: Update all outdated devices with one click
 
+### Finding Devices on the Network
+
+The *Manage Devices* section has a **Find Devices** button that opens a search
+dialog. It offers two searches, and you pick one — nothing runs automatically,
+not even when the dialog opens:
+
+1. **Search via mDNS**: listens for devices announcing themselves. One click, no
+   parameters. It only works when the app shares the network with the devices —
+   inside a bridge-network container it will always come back empty, and says so.
+2. **Scan Network**: probes every address in the range you give it. The field is
+   prefilled with a guess at your local network. The scan sends one HTTP request
+   per address, which is why it takes a deliberate click rather than happening
+   by itself.
+
+The result is a list, not an action. Devices already in your configuration are
+shown but cannot be selected again, and password-protected devices are marked
+"Credentials needed" — discovery never sends credentials, so you add those
+yourself afterwards.
+
+Selecting devices and pressing **Add Selected to List** puts them into the
+editor as *unsaved* rows. Nothing is written to `devices.yaml` until you press
+Save, which gives you the chance to fill in usernames and passwords first.
+
+Closing the dialog stops watching the search, not the search itself — it ends on
+its own within about 25 seconds. That is why the button says "Close" rather than
+"Cancel".
+
 ### Real-time Feedback
 
 The interface provides real-time feedback during operations:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,11 @@ flask-cors>=6.0.1
 flasgger>=0.9.7.1
 marshmallow>=4.0.1
 watchdog>=6.0.0
+# Floor is mandatory, not cosmetic: anything below 0.149.12 carries
+# GHSA-9663-mqmp-p9mm (CVE-2026-48045), an unbounded TC-deferred queue that lets
+# any host on the local link exhaust memory through spoofed mDNS floods — this
+# feature's own threat model.
+zeroconf>=0.149.12
 python-dotenv>=1.2.1
 gunicorn>=23.0.0
 

--- a/tests/e2e/test_discovery.py
+++ b/tests/e2e/test_discovery.py
@@ -1,0 +1,156 @@
+"""End-to-end coverage for the discovery modal.
+
+The job is stubbed through `page.route` rather than scanned for real: the e2e
+run must not depend on what happens to be on the CI runner's network, and a
+real scan would cost 25 seconds per test.
+
+The shared session-scoped `app_server` is fine here because nothing in this
+file saves — adoption only produces unsaved rows, so the repository's
+devices-dev.yaml is never rewritten.
+"""
+import json
+
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.e2e
+
+FINDINGS = [
+    {"ip": "192.168.100.150", "hostname": "tasmota-new", "friendly_name": "Attic",
+     "module": "ESP8266EX", "firmware_version": "14.2.0", "mac": "AA:BB:CC:DD:EE:01",
+     "requires_auth": False, "already_configured": False},
+    {"ip": "192.168.100.101", "hostname": "known", "friendly_name": "Known one",
+     "module": "ESP8266EX", "firmware_version": "13.0.0", "mac": "AA:BB:CC:DD:EE:02",
+     "requires_auth": False, "already_configured": True},
+    {"ip": "192.168.100.151", "hostname": None, "friendly_name": None,
+     "module": None, "firmware_version": None, "mac": None,
+     "requires_auth": True, "already_configured": False},
+]
+
+
+def _stub_discovery(page, results, notice=None, method="scan"):
+    """Answer both discovery endpoints and the job poll with canned data."""
+
+    def handle_discovery(route):
+        if route.request.method == "POST":
+            route.fulfill(
+                status=202, content_type="application/json",
+                body=json.dumps({"job_id": "stub", "status_url": "/api/jobs/stub"}),
+            )
+        else:
+            route.fulfill(
+                status=200, content_type="application/json",
+                body=json.dumps({"suggested_networks": ["192.168.100.0/24"],
+                                 "limits": {"max_prefix": 22, "max_hosts": 1024}}),
+            )
+
+    page.route("**/api/discovery", handle_discovery)
+    page.route("**/api/jobs/stub", lambda route: route.fulfill(
+        status=200, content_type="application/json",
+        body=json.dumps({"job_id": "stub", "kind": "discovery", "method": method,
+                         "status": "completed", "completed": 254, "total": 254,
+                         "results": results, "notice": notice, "error": None}),
+    ))
+
+
+def _open_and_scan(page, app_server):
+    page.goto(app_server)
+    page.get_by_test_id("open-discovery").click()
+    page.get_by_test_id("start-scan").click()
+
+
+def test_scan_lists_findings_and_marks_known_devices(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    _open_and_scan(page, app_server)
+
+    results = page.get_by_test_id("discovery-results")
+    expect(results).to_be_visible()
+    expect(results.locator("tbody tr")).to_have_count(3)
+
+    known_row = results.locator("tbody tr", has_text="192.168.100.101")
+    expect(known_row.locator("input[type=checkbox]")).to_be_disabled()
+    expect(known_row).to_contain_text("Already in list")
+
+
+def test_a_password_protected_find_is_tagged_not_retried(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    _open_and_scan(page, app_server)
+
+    row = page.get_by_test_id("discovery-results").locator(
+        "tbody tr", has_text="192.168.100.151")
+    expect(row).to_contain_text("Credentials needed")
+    # Still adoptable — the user supplies credentials in the editor afterwards.
+    expect(row.locator("input[type=checkbox]")).to_be_enabled()
+
+
+def test_adopting_a_finding_adds_an_unsaved_row(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    _open_and_scan(page, app_server)
+    expect(page.get_by_test_id("discovery-results")).to_be_visible()
+
+    page.locator('input[type=checkbox][value="192.168.100.150"]').check()
+    page.get_by_test_id("adopt-selected").click()
+
+    # x-show only toggles display, so assert visibility — never count == 0.
+    expect(page.get_by_test_id("discovery-modal")).to_be_hidden()
+
+    ip_fields = page.get_by_label("Device IP address")
+    values = [ip_fields.nth(i).input_value() for i in range(ip_fields.count())]
+    assert "192.168.100.150" in values, "the adopted device must appear in the editor"
+
+
+def test_an_already_configured_device_cannot_be_adopted_twice(page, app_server):
+    _stub_discovery(page, FINDINGS)
+    _open_and_scan(page, app_server)
+    expect(page.get_by_test_id("discovery-results")).to_be_visible()
+
+    ip_fields = page.get_by_label("Device IP address")
+    before = [ip_fields.nth(i).input_value() for i in range(ip_fields.count())]
+    assert before.count("192.168.100.101") == 1
+
+    # The checkbox is disabled, so the device can never reach the selection.
+    expect(page.get_by_test_id("adopt-selected")).to_be_disabled()
+
+
+def test_an_empty_mdns_run_explains_itself(page, app_server):
+    _stub_discovery(
+        page, [], method="mdns",
+        notice="No device announced itself. In a bridge-network container mDNS "
+               "cannot work at all, because multicast does not cross the bridge.",
+    )
+    page.goto(app_server)
+    page.get_by_test_id("open-discovery").click()
+    page.get_by_test_id("start-mdns").click()
+
+    notice = page.get_by_test_id("discovery-notice")
+    expect(notice).to_be_visible()
+    expect(notice).to_contain_text("bridge-network")
+    # The honest message replaces the blunt one, it does not accompany it.
+    expect(page.get_by_test_id("discovery-empty")).to_be_hidden()
+
+
+def test_a_rejected_network_is_reported_with_its_reason(page, app_server):
+    """The server's fence must be visible to the user, not swallowed."""
+    def handle_discovery(route):
+        if route.request.method == "POST":
+            route.fulfill(
+                status=400, content_type="application/json",
+                body=json.dumps({"error": "Bad Request",
+                                 "details": "Only private networks can be scanned."}),
+            )
+        else:
+            route.fulfill(
+                status=200, content_type="application/json",
+                body=json.dumps({"suggested_networks": [],
+                                 "limits": {"max_prefix": 22, "max_hosts": 1024}}),
+            )
+
+    page.route("**/api/discovery", handle_discovery)
+    page.goto(app_server)
+    page.get_by_test_id("open-discovery").click()
+    page.get_by_test_id("scan-network").fill("8.8.8.0/24")
+    page.get_by_test_id("start-scan").click()
+
+    error = page.get_by_test_id("discovery-error")
+    expect(error).to_be_visible()
+    expect(error).to_contain_text("private")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -136,3 +136,32 @@ def test_hosts_in_network_leaves_out_network_and_broadcast():
 
     hosts = discovery.hosts_in_network(ipaddress.ip_network("192.168.1.0/29"))
     assert hosts == [f"192.168.1.{n}" for n in range(1, 7)]
+
+
+def test_browse_mdns_raises_when_zeroconf_is_missing(monkeypatch):
+    monkeypatch.setattr(discovery, "_import_zeroconf", lambda: None)
+    with pytest.raises(discovery.MdnsUnavailable):
+        discovery.browse_mdns(duration=0.01)
+
+
+def test_service_info_becomes_a_finding():
+    """The browse callback's translation step, tested without a network."""
+    class FakeInfo:
+        parsed_addresses = staticmethod(lambda: ["192.168.1.42"])
+        server = "tasmota-1234.local."
+        properties = {b"friendly_name": b"Hallway Light", b"module": b"Sonoff Basic"}
+
+    entry = discovery.service_info_to_finding(FakeInfo())
+    assert entry["ip"] == "192.168.1.42"
+    assert entry["hostname"] == "tasmota-1234"
+    assert entry["friendly_name"] == "Hallway Light"
+    assert entry["requires_auth"] is False
+
+
+def test_service_info_without_an_address_is_skipped():
+    class FakeInfo:
+        parsed_addresses = staticmethod(lambda: [])
+        server = "ghost.local."
+        properties = {}
+
+    assert discovery.service_info_to_finding(FakeInfo()) is None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,42 @@
+"""Unit tests for the discovery core."""
+import pytest
+
+from app.tasmota import discovery
+
+TASMOTA_STATUS = {
+    "Status": {"Module": 1, "DeviceName": "Hallway", "FriendlyName": ["Hallway Light"]},
+    "StatusFWR": {"Version": "14.2.0(release-tasmota)", "Hardware": "ESP8266EX"},
+    "StatusNET": {"Hostname": "tasmota-1234", "IPAddress": "192.168.1.42",
+                  "Mac": "AA:BB:CC:DD:EE:FF"},
+}
+
+
+def test_parse_status_extracts_the_fields_the_ui_shows():
+    result = discovery.parse_status(TASMOTA_STATUS, "192.168.1.42")
+    assert result == {
+        "ip": "192.168.1.42",
+        "hostname": "tasmota-1234",
+        "friendly_name": "Hallway Light",
+        "module": "ESP8266EX",
+        "firmware_version": "14.2.0(release-tasmota)",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "requires_auth": False,
+    }
+
+
+def test_parse_status_survives_a_sparse_payload():
+    """A minimal device still answers Status 0 — it must not crash the scan."""
+    result = discovery.parse_status({"Status": {}}, "192.168.1.7")
+    assert result is not None
+    assert result["ip"] == "192.168.1.7"
+    assert result["firmware_version"] is None
+    assert result["friendly_name"] is None
+
+
+def test_parse_status_rejects_a_foreign_json_device():
+    """A printer answering JSON is not a Tasmota. No Status block, no entry."""
+    assert discovery.parse_status({"printer": {"model": "X"}}, "192.168.1.9") is None
+
+
+def test_parse_status_rejects_a_non_mapping():
+    assert discovery.parse_status([1, 2, 3], "192.168.1.9") is None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,4 +1,8 @@
 """Unit tests for the discovery core."""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 import pytest
 
 from app.tasmota import discovery
@@ -40,3 +44,95 @@ def test_parse_status_rejects_a_foreign_json_device():
 
 def test_parse_status_rejects_a_non_mapping():
     assert discovery.parse_status([1, 2, 3], "192.168.1.9") is None
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Answers like the device its `mode` says. Set by the factory below."""
+
+    mode = "tasmota"
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler's interface
+        if self.mode == "tasmota":
+            body = json.dumps(TASMOTA_STATUS).encode()
+            self.send_response(200)
+        elif self.mode == "auth":
+            body = json.dumps({"WARNING": "Need user&password"}).encode()
+            self.send_response(401)
+        else:
+            body = json.dumps({"printer": {"model": "X"}}).encode()
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # keep the test output readable
+        pass
+
+
+def _start_stub(mode):
+    handler = type("Handler", (_StubHandler,), {"mode": mode})
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+@pytest.fixture
+def stub_servers():
+    servers = {mode: _start_stub(mode) for mode in ("tasmota", "auth", "foreign")}
+    yield {mode: s.server_address[1] for mode, s in servers.items()}
+    for server in servers.values():
+        server.shutdown()
+
+
+def test_scan_finds_real_devices_without_mocking_the_probe(stub_servers):
+    """The one test that drives the real probe over a real socket.
+
+    Mocking probe_host here would only prove that a thread pool calls a
+    function — exactly the blind spot that let #126 ship.
+    """
+    found = []
+    for mode, port in stub_servers.items():
+        results = discovery.scan_network(
+            ["127.0.0.1"],
+            probe=lambda ip, port=port: discovery.probe_host(ip, port=port, timeout=2.0),
+        )
+        found.extend(results)
+
+    by_auth = {entry["requires_auth"]: entry for entry in found}
+    assert len(found) == 2, "the foreign JSON device must not be reported"
+    assert by_auth[False]["firmware_version"] == "14.2.0(release-tasmota)"
+    assert by_auth[True]["ip"] == "127.0.0.1"
+
+
+def test_scan_reports_progress_for_every_host():
+    seen = []
+    discovery.scan_network(
+        [f"192.0.2.{n}" for n in range(1, 6)],
+        probe=lambda ip: None,
+        on_progress=lambda completed, total: seen.append((completed, total)),
+    )
+    assert [c for c, _ in seen] == [1, 2, 3, 4, 5]
+    assert {t for _, t in seen} == {5}
+
+
+def test_scan_survives_a_probe_that_raises():
+    """One broken host must not abort the whole range."""
+    def flaky(ip):
+        if ip.endswith(".2"):
+            raise RuntimeError("boom")
+        return {"ip": ip, "requires_auth": False}
+
+    results = discovery.scan_network(["192.0.2.1", "192.0.2.2", "192.0.2.3"], probe=flaky)
+    assert sorted(r["ip"] for r in results) == ["192.0.2.1", "192.0.2.3"]
+
+
+def test_scan_of_an_empty_range_does_nothing():
+    assert discovery.scan_network([]) == []
+
+
+def test_hosts_in_network_leaves_out_network_and_broadcast():
+    import ipaddress
+
+    hosts = discovery.hosts_in_network(ipaddress.ip_network("192.168.1.0/29"))
+    assert hosts == [f"192.168.1.{n}" for n in range(1, 7)]

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -1,0 +1,169 @@
+"""Contract tests for the discovery endpoints."""
+import pytest
+from marshmallow import ValidationError
+
+from app.tasmota import api, jobs
+from server import create_app
+
+MAX_PREFIX = 22
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    jobs._reset_for_tests()
+    yield
+    jobs._reset_for_tests()
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.test_client() as test_client:
+        with test_client.session_transaction() as session:
+            session["ui_authenticated"] = True
+        yield test_client
+
+
+@pytest.mark.parametrize("value", [
+    "192.168.1.0/24", "10.0.0.0/24", "172.16.4.0/23", "192.168.0.0/22",
+])
+def test_private_networks_within_the_limit_are_accepted(value):
+    assert str(api.validate_scan_target(value)) == value
+
+
+def test_a_host_address_is_normalised_to_its_network():
+    """Typing your own address with a prefix must mean 'this network'.
+
+    Nobody looks up their network address before scanning — they read the IP
+    off a device. strict=False turns that into the range they meant.
+    """
+    assert str(api.validate_scan_target("192.168.1.55/24")) == "192.168.1.0/24"
+
+
+def test_whitespace_around_the_network_is_tolerated():
+    """Copy-paste from a router page brings whitespace along."""
+    assert str(api.validate_scan_target("  10.0.0.0/24  ")) == "10.0.0.0/24"
+
+
+@pytest.mark.parametrize("value,reason", [
+    ("8.8.8.0/24", "public"),
+    ("127.0.0.0/24", "loopback"),
+    ("169.254.0.0/24", "link-local"),
+    ("224.0.0.0/24", "multicast"),
+    ("192.168.0.0/16", "too large"),
+    ("not-a-network", "garbage"),
+    ("fd00::/64", "IPv6"),
+    ("", "empty"),
+])
+def test_targets_outside_the_fence_are_rejected(value, reason):
+    with pytest.raises(ValidationError):
+        api.validate_scan_target(value)
+
+
+def test_get_discovery_offers_a_suggestion_and_the_limits(client):
+    response = client.get("/api/discovery")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["limits"] == {"max_prefix": MAX_PREFIX, "max_hosts": 1024}
+    assert isinstance(body["suggested_networks"], list)
+
+
+def test_post_scan_starts_a_job(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: "job-1")
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "192.168.1.0/24"})
+    assert response.status_code == 202
+    assert response.get_json()["job_id"] == "job-1"
+
+
+def test_post_scan_passes_the_expanded_host_list(client, monkeypatch):
+    """The API expands the CIDR; the core never sees a network object."""
+    captured = {}
+
+    def fake_job(method, hosts, **kwargs):
+        captured["method"] = method
+        captured["hosts"] = hosts
+        return "job-x"
+
+    monkeypatch.setattr(jobs, "create_discovery_job", fake_job)
+    client.post("/api/discovery", json={"method": "scan", "network": "192.168.1.0/29"})
+    assert captured["method"] == "scan"
+    assert captured["hosts"] == [f"192.168.1.{n}" for n in range(1, 7)]
+
+
+def test_post_mdns_starts_a_job(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: "job-2")
+    response = client.post("/api/discovery", json={"method": "mdns"})
+    assert response.status_code == 202
+
+
+def test_post_rejects_a_public_network_with_a_reason(client):
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "8.8.8.0/24"})
+    assert response.status_code == 400
+    assert "private" in response.get_json()["details"].lower()
+
+
+def test_post_reports_a_running_job_as_conflict(client, monkeypatch):
+    monkeypatch.setattr(jobs, "create_discovery_job", lambda *a, **kw: None)
+    response = client.post("/api/discovery",
+                           json={"method": "scan", "network": "192.168.1.0/24"})
+    assert response.status_code == 409
+
+
+def test_post_requires_json(client):
+    response = client.post("/api/discovery", data="method=scan",
+                           content_type="application/x-www-form-urlencoded")
+    assert response.status_code == 415
+
+
+def test_post_rejects_an_unknown_method(client):
+    response = client.post("/api/discovery", json={"method": "arp-spoof"})
+    assert response.status_code == 400
+
+
+def test_discovery_is_behind_the_auth_gate():
+    """Fail-closed, like every other /api/* route."""
+    app = create_app()
+    app.config.update({"TESTING": True})
+    with app.test_client() as anonymous:
+        assert anonymous.get("/api/discovery").status_code == 401
+        assert anonymous.post("/api/discovery", json={"method": "mdns"}).status_code == 401
+
+
+def test_findings_are_flagged_against_the_configured_devices(client, tmp_path):
+    """A device already in the file must not be offered for adoption again."""
+    devices_file = tmp_path / "devices.yaml"
+    devices_file.write_text("devices:\n  - ip: 192.168.1.10\n")
+
+    job_id = jobs.create_discovery_job(
+        "scan", ["192.168.1.10", "192.168.1.11"],
+        runner=lambda on_progress: [
+            {"ip": "192.168.1.10", "requires_auth": False},
+            {"ip": "192.168.1.11", "requires_auth": False},
+        ],
+        background=False,
+    )
+
+    app = create_app()
+    app.config.update({"TESTING": True, "DEVICES_FILE": str(devices_file)})
+    with app.test_client() as authed:
+        with authed.session_transaction() as session:
+            session["ui_authenticated"] = True
+        body = authed.get(f"/api/jobs/{job_id}").get_json()
+
+    flags = {entry["ip"]: entry["already_configured"] for entry in body["results"]}
+    assert flags == {"192.168.1.10": True, "192.168.1.11": False}
+
+
+def test_batch_job_results_are_left_alone(client):
+    """The enrichment is discovery-only; a batch result must not grow a flag."""
+    job_id = jobs.create_batch_job(
+        [{"ip": "192.0.2.9"}], check_only=True, update_only_needed=False,
+        global_timeout=None,
+        updater=lambda cfg, check_only=False: {"success": True, "ip": cfg["ip"]},
+        background=False,
+    )
+    body = client.get(f"/api/jobs/{job_id}").get_json()
+    assert "already_configured" not in body["results"][0]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,9 +1,10 @@
 """Unit tests for the background batch-job runner (Phase 2)."""
 import threading
+import time
 
 import pytest
 
-from app.tasmota import jobs
+from app.tasmota import discovery, jobs
 
 
 @pytest.fixture(autouse=True)
@@ -85,3 +86,101 @@ def test_only_one_batch_at_a_time():
 
 def test_unknown_job_is_none():
     assert jobs.get_job("nope") is None
+
+
+def test_a_running_discovery_job_does_not_block_a_batch_update():
+    """The deadlock this design had to sidestep.
+
+    Both kinds share one store. If the batch exclusivity check keeps looking
+    at every job in it, a scan blocks every update for as long as it runs —
+    silently, and only in production where scans are slow.
+    """
+    def slow_scan(on_progress):
+        time.sleep(0.2)
+        return []
+
+    discovery_id = jobs.create_discovery_job("scan", ["192.0.2.1"], runner=slow_scan)
+    assert discovery_id is not None
+
+    batch_id = jobs.create_batch_job(
+        [{"ip": "192.0.2.9"}], check_only=True, update_only_needed=False,
+        global_timeout=None, updater=lambda cfg, check_only=False: {"success": True},
+        background=False,
+    )
+    assert batch_id is not None, "a running scan must not block a batch update"
+    assert jobs.get_job(batch_id)["kind"] == "batch"
+    assert jobs.get_job(discovery_id)["kind"] == "discovery"
+
+
+def test_a_running_batch_update_does_not_block_discovery():
+    """The same trap, from the other side."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_updater(config, check_only=False):
+        started.set()
+        release.wait(timeout=2)
+        return {"success": True, "ip": config["ip"]}
+
+    jobs.create_batch_job(
+        [{"ip": "192.0.2.9"}], check_only=True, update_only_needed=False,
+        global_timeout=None, updater=blocking_updater,
+    )
+    assert started.wait(timeout=2)
+
+    discovery_id = jobs.create_discovery_job(
+        "scan", ["192.0.2.1"], runner=lambda on_progress: [], background=False
+    )
+    release.set()
+    assert discovery_id is not None, "a running batch update must not block a scan"
+
+
+def test_only_one_discovery_job_runs_at_a_time():
+    def slow_scan(on_progress):
+        time.sleep(0.2)
+        return []
+
+    assert jobs.create_discovery_job("scan", ["192.0.2.1"], runner=slow_scan) is not None
+    assert jobs.create_discovery_job("scan", ["192.0.2.2"], runner=slow_scan) is None
+
+
+def test_discovery_job_records_results_and_progress():
+    finding = {"ip": "192.0.2.5", "requires_auth": False}
+
+    def runner(on_progress):
+        on_progress(1, 1)
+        return [finding]
+
+    job_id = jobs.create_discovery_job("scan", ["192.0.2.5"], runner=runner, background=False)
+    job = jobs.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["results"] == [finding]
+    assert job["completed"] == 1 and job["total"] == 1
+
+
+def test_an_empty_mdns_run_explains_why_rather_than_claiming_emptiness():
+    job_id = jobs.create_discovery_job(
+        "mdns", None, runner=lambda on_progress: [], background=False
+    )
+    job = jobs.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["results"] == []
+    assert "bridge" in job["notice"]
+
+
+def test_an_empty_scan_gets_no_mdns_notice():
+    """The notice is about multicast, so it must not appear on a scan."""
+    job_id = jobs.create_discovery_job(
+        "scan", ["192.0.2.1"], runner=lambda on_progress: [], background=False
+    )
+    assert jobs.get_job(job_id)["notice"] is None
+
+
+def test_mdns_job_without_zeroconf_ends_as_error():
+    def runner(on_progress):
+        raise discovery.MdnsUnavailable("no zeroconf here")
+
+    job_id = jobs.create_discovery_job("mdns", None, runner=runner, background=False)
+    job = jobs.get_job(job_id)
+    assert job["status"] == "error"
+    assert "zeroconf" in job["error"]


### PR DESCRIPTION
Closes #99 (second and final cycle — the devices editor from #128 was the first).

Finds Tasmota devices on the LAN and lets you adopt them into the device list,
instead of collecting IP addresses by hand.

## What this adds

Two **explicit** searches, chosen by the user — no automatic fallback from one
into the other, and nothing starts on its own:

- **mDNS** — passive, one click. Browses `_http._tcp` and `_tasmota._tcp`.
- **Network scan** — probes every address in a given range with
  `GET /cm?cmnd=Status%200`.

Findings are suggestions. Selected devices become **unsaved rows** in the
editor; nothing reaches `devices.yaml` until you press Save. Discovery has no
write path at all, so `device_config` keeps exactly one caller.

New: `app/tasmota/discovery.py` (pure search logic), `GET`/`POST /api/discovery`,
a discovery job kind in the existing store, and a modal in the web UI.

## The two traps this had to avoid

**A second job kind would have deadlocked the first.** `batch_in_progress()` and
the exclusivity check in `create_batch_job()` looked at *every* job in the shared
store. Adding discovery without scoping them means a running scan silently blocks
every batch update — and only in production, where scans are slow enough to
overlap. Both checks are now scoped by `kind`, with a regression test in both
directions.

**Mocking the scanner would have proven nothing.** Every `--force` test in #126
mocked the runner and thereby hid that the core could not do what the surface
promised. So the scan policy lives in the API layer, not in the core — which is
what lets one test drive the *real* `probe_host` over real sockets against three
loopback stubs (Tasmota, 401, foreign JSON). The policy forbids loopback; had it
lived in the scanner, that test would have been impossible.

## Security

The scanner sits behind the fail-closed gate from #69 and is fenced so it cannot
be widened from the browser:

- private IPv4 only, prefix >= /22 — a scan of public address space is rejected
- concurrency (64) and per-host timeout (1.5 s) are fixed, not API parameters:
  a per-request concurrency knob behind a session is a DoS button
- no redirects, no retries, response body capped at 64 KiB
- **no credentials are ever sent** — not even stored ones. A password-protected
  device is reported as `requires_auth` and left alone; retrying it with stored
  passwords would be credential spraying
- no scan starts automatically, not even when the dialog opens

`zeroconf` is pinned `>=0.149.12`. Anything older carries GHSA-9663-mqmp-p9mm
(CVE-2026-48045) — a LAN-local memory exhaustion through flooded TC-bit mDNS
queries, which is precisely this feature's own threat model. Vetting: OSV clean
at 0.150.0, first released 2014-07-08, 262 versions, python-zeroconf org, no
typosquat lookalikes.

This also yields a ready-made section for the threat model in #74.

## Honesty

An mDNS run that finds nothing in a bridge-network container says *why*
(multicast does not cross the bridge) instead of claiming no devices exist. The
scan deliberately gets no such notice — there, empty really does mean nothing
answered. Same line as `isVersionComparisonKnown()` in #91.

The scan shows a real progress bar from `completed`/`total`; mDNS shows a
spinner, because no total exists there and inventing one would be a lie.

## Documentation

Beyond documenting discovery itself, this corrects `docs/api.md`, which had
drifted badly and independently of this feature:

- **every** documented endpoint carried an `/api/v1` prefix that never existed —
  following the page gave 404 on every call
- it claimed the API needs no authentication; it has been fail-closed since
  v0.5.0
- `POST /api/update/all` was documented as synchronous; it returns `202` with a
  job id
- `/api/config/devices` — the editor endpoint from #128 — was missing entirely

Every example in the corrected page was executed against a running instance
rather than written from memory.

## Testing

- green core: **243 passed**
- full e2e suite: **14 passed** (not just the new file — new markup breaks
  existing tests through Playwright strict mode)
- the core scan path tested **unmocked** against real loopback HTTP servers
- both searches driven by hand against a running app: a 254-address scan
  completed with live progress, and a real mDNS run returned the honest notice
- `mkdocs build --strict` clean, README reviewed per the checklist

## Deployment

No new environment variable, and no change is required: the range scan works in
the default bridge-network container. mDNS needs `network_mode: host`, which is
documented together with what it costs (no network isolation, no port mapping,
Linux only) rather than being recommended outright.
