### PR TITLE
docs(changelog): call out the mount migration in the 0.6.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## [0.6.0](https://github.com/dodjango/tasmota-auto-updater/compare/v0.5.4...v0.6.0) (2026-08-08)
 
 
+### ⚠️ Breaking change: mount the configuration directory, not the file
+
+The new device editor writes `devices.yaml`, and replacing a file that is bind-mounted individually fails with `EBUSY`. Mount its **directory** instead:
+
+```yaml
+- ./config:/app/config          # was: ./devices.yaml:/app/devices.yaml
+```
+
+Move `devices.yaml` into that directory. The image now defaults to `DEVICES_FILE=/app/config/devices.yaml`, so no extra environment variable is needed.
+
+Deployments that keep the old single-file mount keep working — the editor stays read-only and explains why in the UI.
+
+
+### Note on device discovery
+
+The new network discovery needs no deployment change: the IP range scan works in the default bridge-network container.
+
+mDNS does not, and cannot — multicast does not cross a container bridge, so that search will always come back empty there (the UI says so rather than claiming no devices exist). If you want mDNS, the container has to run with `network_mode: host`, which costs network isolation and port mapping and only helps on Linux. See [Container Setup](docs/container-setup.md) for the trade-off.
+
+
 ### Features
 
 * **cli:** add a thin CLI over the maintained core ([#127](https://github.com/dodjango/tasmota-auto-updater/issues/127)) ([54a0b7a](https://github.com/dodjango/tasmota-auto-updater/commit/54a0b7ad5ffea84e115024a0118101ba6e9ab6cd))


### PR DESCRIPTION
Brings `CHANGELOG.md` in line with the published v0.6.0 release notes.

## Why

The generated 0.6.0 section listed the three features without mentioning that
the device editor requires a **directory** mount. Anyone upgrading a container
deployment would meet that as a read-only editor with no obvious cause —
`rename()` over a single-file bind mount fails with `EBUSY`.

The note also covers discovery, which raises the same deployment question from
the other side: the range scan needs no change at all, while mDNS cannot work
in a bridge-network container, because multicast does not cross the bridge.

## Provenance

The wording is Torsten's, from commit `e12b283` on the `rp-release` branch. That
branch was never merged, so the note missed the release. The published release
notes have already been corrected by hand; this PR stops the file in the
repository from disagreeing with them.

The only intentional difference is the documentation link — absolute in the
release notes, relative here, because relative links do not resolve in release
notes.

## No release side effects

`docs` is configured `hidden: true` in `release-please-config.json`, so this
commit will not surface as an entry in the next release's changelog. It edits
an already-published section and does not touch the version manifest.
